### PR TITLE
Adjust Makefile to standard structure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,32 +41,41 @@ LOCAL_PROMETHEUS_DATA_DIR := ./.temp/prometheus/data
 LOCAL_GRAFANA_DATA_DIR := ./.temp/grafana/data
 
 .PHONY: help info prepare-dirs \
-        up down clean redeploy \
-        local-up local-down local-clean local-redeploy \
-        local-demo-up local-demo-down local-demo-clean local-demo-redeploy \
-        demo-up demo-down demo-clean demo-redeploy
+        up down restart recreate rebuild clean \
+        local-up local-down local-restart local-recreate local-rebuild local-clean \
+        local-demo-up local-demo-down local-demo-restart local-demo-recreate local-demo-rebuild local-demo-clean \
+        demo-up demo-down demo-restart demo-recreate demo-rebuild demo-clean \
+        local-up-svc local-stop-svc local-restart-svc local-recreate-svc local-rebuild-svc \
+        local-demo-up-svc local-demo-stop-svc local-demo-restart-svc local-demo-recreate-svc local-demo-rebuild-svc \
+        demo-up-svc demo-stop-svc demo-restart-svc demo-recreate-svc demo-rebuild-svc
 
 help:
-	@echo "Targets:"
-	@echo "  make up                  Up local dev stack (ports exposed)"
-	@echo "  make down                Down local dev stack (remove orphans)"
-	@echo "  make clean               Down local dev stack + remove volumes"
-	@echo "  make redeploy            Up local dev stack (rebuild)"
+	@echo "Conventions:"
+	@echo "  up       -> start/update containers (no build)"
+	@echo "  down     -> stop/remove containers + network (keep volumes)"
+	@echo "  restart  -> restart existing containers (no recreate)"
+	@echo "  recreate -> force re-create containers (keep volumes)"
+	@echo "  rebuild  -> build images + start (keep volumes)"
+	@echo "  clean    -> down + remove volumes (DATA LOSS)"
 	@echo ""
-	@echo "  make local-up            Up local dev stack (ports exposed)"
-	@echo "  make local-down          Down local dev stack (remove orphans)"
-	@echo "  make local-clean         Down local dev stack + remove volumes"
-	@echo "  make local-redeploy      Up local dev stack (rebuild)"
+	@echo "Default (alias -> local-demo):"
+	@echo "  make up | down | restart | recreate | rebuild | clean"
 	@echo ""
-	@echo "  make local-demo-up       Up local demo stack (demo profile + dummy + ports)"
-	@echo "  make local-demo-down     Down local demo stack (remove orphans)"
-	@echo "  make local-demo-clean    Down local demo stack + remove volumes"
-	@echo "  make local-demo-redeploy Up local demo stack (rebuild)"
+	@echo "Local:"
+	@echo "  make local-up | local-down | local-restart | local-recreate | local-rebuild | local-clean"
+	@echo "  make local-up-svc <svc...>"
+	@echo "  make local-stop-svc <svc...>"
+	@echo "  make local-restart-svc <svc...>"
+	@echo "  make local-recreate-svc <svc...>"
+	@echo "  make local-rebuild-svc <svc...>"
 	@echo ""
-	@echo "  make demo-up             Up demo stack (dummy enabled, no ports by default)"
-	@echo "  make demo-down           Down demo stack (remove orphans)"
-	@echo "  make demo-clean          Down demo stack + remove volumes"
-	@echo "  make demo-redeploy       Up demo stack (rebuild)"
+	@echo "Local demo:"
+	@echo "  make local-demo-up | local-demo-down | local-demo-restart | local-demo-recreate | local-demo-rebuild | local-demo-clean"
+	@echo "  make local-demo-*-svc <svc...>"
+	@echo ""
+	@echo "Demo (AWS / public):"
+	@echo "  make demo-up | demo-down | demo-restart | demo-recreate | demo-rebuild | demo-clean"
+	@echo "  make demo-*-svc <svc...>"
 	@echo ""
 	@echo "Variables:"
 	@echo "  COMPOSE=\"docker compose\"  Override compose command"
@@ -83,20 +92,30 @@ else
 	@mkdir -p $(LOCAL_GRAFANA_DATA_DIR)
 endif
 
-# ---- local ----
+# ---- default aliases ----
+# Keep existing behavior: default targets operate on local-demo.
 up: local-demo-up
 down: local-demo-down
+restart: local-demo-restart
+recreate: local-demo-recreate
+rebuild: local-demo-rebuild
 clean: local-demo-clean
-redeploy: local-demo-redeploy
 
+# ---- local ----
 local-up: info prepare-dirs
 	$(COMPOSE) $(LOCAL_PROJECT) $(LOCAL_STACK) up --detach --remove-orphans
 
-local-redeploy: info prepare-dirs
-	$(COMPOSE) $(LOCAL_PROJECT) $(LOCAL_STACK) up --detach --build --remove-orphans
-
 local-down: info
 	$(COMPOSE) $(LOCAL_PROJECT) $(LOCAL_STACK) down --remove-orphans
+
+local-restart: info
+	$(COMPOSE) $(LOCAL_PROJECT) $(LOCAL_STACK) restart
+
+local-recreate: info
+	$(COMPOSE) $(LOCAL_PROJECT) $(LOCAL_STACK) up --detach --force-recreate --remove-orphans
+
+local-rebuild: info prepare-dirs
+	$(COMPOSE) $(LOCAL_PROJECT) $(LOCAL_STACK) up --detach --build --remove-orphans
 
 local-clean: info
 	$(COMPOSE) $(LOCAL_PROJECT) $(LOCAL_STACK) down --remove-orphans --volumes
@@ -105,11 +124,17 @@ local-clean: info
 local-demo-up: info prepare-dirs
 	$(COMPOSE) $(LOCAL_DEMO_PROJECT) $(LOCAL_DEMO_STACK) up --detach --remove-orphans
 
-local-demo-redeploy: info prepare-dirs
-	$(COMPOSE) $(LOCAL_DEMO_PROJECT) $(LOCAL_DEMO_STACK) up --detach --build --remove-orphans
-
 local-demo-down: info
 	$(COMPOSE) $(LOCAL_DEMO_PROJECT) $(LOCAL_DEMO_STACK) down --remove-orphans
+
+local-demo-restart: info
+	$(COMPOSE) $(LOCAL_DEMO_PROJECT) $(LOCAL_DEMO_STACK) restart
+
+local-demo-recreate: info
+	$(COMPOSE) $(LOCAL_DEMO_PROJECT) $(LOCAL_DEMO_STACK) up --detach --force-recreate --remove-orphans
+
+local-demo-rebuild: info prepare-dirs
+	$(COMPOSE) $(LOCAL_DEMO_PROJECT) $(LOCAL_DEMO_STACK) up --detach --build --remove-orphans
 
 local-demo-clean: info
 	$(COMPOSE) $(LOCAL_DEMO_PROJECT) $(LOCAL_DEMO_STACK) down --remove-orphans --volumes
@@ -118,11 +143,103 @@ local-demo-clean: info
 demo-up: info
 	$(COMPOSE) $(DEMO_PROJECT) $(DEMO_STACK) up --detach --remove-orphans
 
-demo-redeploy: info
-	$(COMPOSE) $(DEMO_PROJECT) $(DEMO_STACK) up --detach --build --remove-orphans
-
 demo-down: info
 	$(COMPOSE) $(DEMO_PROJECT) $(DEMO_STACK) down --remove-orphans
 
+demo-restart: info
+	$(COMPOSE) $(DEMO_PROJECT) $(DEMO_STACK) restart
+
+demo-recreate: info
+	$(COMPOSE) $(DEMO_PROJECT) $(DEMO_STACK) up --detach --force-recreate --remove-orphans
+
+demo-rebuild: info
+	$(COMPOSE) $(DEMO_PROJECT) $(DEMO_STACK) up --detach --build --remove-orphans
+
 demo-clean: info
 	$(COMPOSE) $(DEMO_PROJECT) $(DEMO_STACK) down --remove-orphans --volumes
+
+# ---- service-scoped commands (positional service args) ----
+# Usage examples:
+#   make demo-restart-svc caddy grafana
+#   make local-demo-recreate-svc aggregator prometheus
+#
+SERVICE_TARGETS := \
+  local-up-svc local-stop-svc local-restart-svc local-recreate-svc local-rebuild-svc \
+  local-demo-up-svc local-demo-stop-svc local-demo-restart-svc local-demo-recreate-svc local-demo-rebuild-svc \
+  demo-up-svc demo-stop-svc demo-restart-svc demo-recreate-svc demo-rebuild-svc
+
+ifneq ($(filter $(SERVICE_TARGETS),$(MAKECMDGOALS)),)
+SERVICES := $(filter-out $(SERVICE_TARGETS),$(MAKECMDGOALS))
+$(SERVICES):
+	@:
+endif
+
+define require_services
+	@if [ -z "$(SERVICES)" ]; then \
+	  echo "ERROR: No services specified. Example: make $(1) caddy grafana"; \
+	  exit 1; \
+	fi
+endef
+
+# local services
+local-up-svc: info prepare-dirs
+	$(call require_services,local-up-svc)
+	$(COMPOSE) $(LOCAL_PROJECT) $(LOCAL_STACK) up --detach --remove-orphans $(SERVICES)
+
+local-stop-svc: info
+	$(call require_services,local-stop-svc)
+	$(COMPOSE) $(LOCAL_PROJECT) $(LOCAL_STACK) stop $(SERVICES)
+
+local-restart-svc: info
+	$(call require_services,local-restart-svc)
+	$(COMPOSE) $(LOCAL_PROJECT) $(LOCAL_STACK) restart $(SERVICES)
+
+local-recreate-svc: info
+	$(call require_services,local-recreate-svc)
+	$(COMPOSE) $(LOCAL_PROJECT) $(LOCAL_STACK) up --detach --force-recreate $(SERVICES)
+
+local-rebuild-svc: info prepare-dirs
+	$(call require_services,local-rebuild-svc)
+	$(COMPOSE) $(LOCAL_PROJECT) $(LOCAL_STACK) up --detach --build $(SERVICES)
+
+# local-demo services
+local-demo-up-svc: info prepare-dirs
+	$(call require_services,local-demo-up-svc)
+	$(COMPOSE) $(LOCAL_DEMO_PROJECT) $(LOCAL_DEMO_STACK) up --detach --remove-orphans $(SERVICES)
+
+local-demo-stop-svc: info
+	$(call require_services,local-demo-stop-svc)
+	$(COMPOSE) $(LOCAL_DEMO_PROJECT) $(LOCAL_DEMO_STACK) stop $(SERVICES)
+
+local-demo-restart-svc: info
+	$(call require_services,local-demo-restart-svc)
+	$(COMPOSE) $(LOCAL_DEMO_PROJECT) $(LOCAL_DEMO_STACK) restart $(SERVICES)
+
+local-demo-recreate-svc: info
+	$(call require_services,local-demo-recreate-svc)
+	$(COMPOSE) $(LOCAL_DEMO_PROJECT) $(LOCAL_DEMO_STACK) up --detach --force-recreate $(SERVICES)
+
+local-demo-rebuild-svc: info prepare-dirs
+	$(call require_services,local-demo-rebuild-svc)
+	$(COMPOSE) $(LOCAL_DEMO_PROJECT) $(LOCAL_DEMO_STACK) up --detach --build $(SERVICES)
+
+# demo services
+demo-up-svc: info
+	$(call require_services,demo-up-svc)
+	$(COMPOSE) $(DEMO_PROJECT) $(DEMO_STACK) up --detach --remove-orphans $(SERVICES)
+
+demo-stop-svc: info
+	$(call require_services,demo-stop-svc)
+	$(COMPOSE) $(DEMO_PROJECT) $(DEMO_STACK) stop $(SERVICES)
+
+demo-restart-svc: info
+	$(call require_services,demo-restart-svc)
+	$(COMPOSE) $(DEMO_PROJECT) $(DEMO_STACK) restart $(SERVICES)
+
+demo-recreate-svc: info
+	$(call require_services,demo-recreate-svc)
+	$(COMPOSE) $(DEMO_PROJECT) $(DEMO_STACK) up --detach --force-recreate $(SERVICES)
+
+demo-rebuild-svc: info
+	$(call require_services,demo-rebuild-svc)
+	$(COMPOSE) $(DEMO_PROJECT) $(DEMO_STACK) up --detach --build $(SERVICES)


### PR DESCRIPTION
- Clear standard naming for the operations: `up down restart recreate rebuild clean`
- Now `recreate` can be used to force-restart all the containers without cleaning volumes.
- Less likely to accidentally remove SSL certificate with the volume.