### PR TITLE
Local: use docker volumes, not specific path for data

### DIFF
--- a/compose.local-demo.yaml
+++ b/compose.local-demo.yaml
@@ -10,7 +10,7 @@ services:
     image: prom/prometheus:v2.54.1
     volumes:
       - ${PROMETHEUS_CONFIG_FILE:-./monitoring/prometheus/prometheus.yml}:/etc/prometheus/prometheus.yml:ro
-      - ./.temp/prometheus/data:/prometheus
+      - prometheus-data:/prometheus
 
   grafana:
     image: grafana/grafana:12.3.1
@@ -22,4 +22,8 @@ services:
       GF_USERS_ANONYMOUS_DEVICE_PREFERENCES: "true"
     volumes:
       - ${GRAFANA_PROVISIONING_DIR:-./monitoring/grafana/provisioning}:/etc/grafana/provisioning:ro
-      - ./.temp/grafana/data:/var/lib/grafana
+      - grafana-data:/var/lib/grafana
+
+volumes:
+  prometheus-data:
+  grafana-data:

--- a/compose.local.yaml
+++ b/compose.local.yaml
@@ -9,7 +9,7 @@ services:
     image: prom/prometheus:v2.54.1
     volumes:
       - ${PROMETHEUS_CONFIG_FILE:-./monitoring/prometheus/prometheus.yml}:/etc/prometheus/prometheus.yml:ro
-      - ./.temp/prometheus/data:/prometheus
+      - prometheus-data:/prometheus
 
   grafana:
     image: grafana/grafana:12.3.1
@@ -21,4 +21,8 @@ services:
       GF_USERS_ANONYMOUS_DEVICE_PREFERENCES: "true"
     volumes:
       - ${GRAFANA_PROVISIONING_DIR:-./monitoring/grafana/provisioning}:/etc/grafana/provisioning:ro
-      - ./.temp/grafana/data:/var/lib/grafana
+      - grafana-data:/var/lib/grafana
+
+volumes:
+  prometheus-data:
+  grafana-data:


### PR DESCRIPTION
- Updated compose.local.yaml and compose.local-demo.yaml to use named volumes (prometheus-data, grafana-data) instead of local bind mounts. 
- Added volumes: declarations for prometheus-data and grafana-data in both files.

### Result
- Aligned local compose files with compose.yaml/compose.demo.yaml and remove host-path dependencies.
- Ensured Docker creates/manages the named volumes and keeps data portability consistent.