### PR TITLE
Switch Demo to non-dev SSL certificate

### DIFF
--- a/deploy/demo/Caddyfile
+++ b/deploy/demo/Caddyfile
@@ -1,5 +1,4 @@
 {
-    acme_ca https://acme-staging-v02.api.letsencrypt.org/directory
     servers {
                 protocols h1 h2
             }


### PR DESCRIPTION
- Tested working with DEV certificate
- Now switching to the one which won't show "Untrusted" warning