### PR TITLE
Move demo to subdomain

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ from the states of those services.
 
 Available on EC2 public instance, uses Grafana for visualization:
 
-- https://alivion.cc/health-aggregator
+- https://aggregator.alivion.cc
 
 Example dashboards:
 
-- [Dashboard - Current state for "business_suite"](https://alivion.cc/health-aggregator/d/catalog-item-state-current/catalog-item-state-current?var-item_id=business-suite)
-- [Dashboard - State timeline for "business_suite"](https://alivion.cc/health-aggregator/d/catalog-item-state-timeline/catalog-item-state-timeline?var-item_id=business-suite)
+- [Dashboard - Current state for "business_suite"](https://aggregator.alivion.cc/d/catalog-item-state-current/catalog-item-state-current?var-item_id=business-suite)
+- [Dashboard - State timeline for "business_suite"](https://aggregator.alivion.cc/d/catalog-item-state-timeline/catalog-item-state-timeline?var-item_id=business-suite)
 
 **Note:** A TLS certificate browser warning is expected because the certificate is self-signed.
 

--- a/aggregator-ui/src/App.jsx
+++ b/aggregator-ui/src/App.jsx
@@ -60,6 +60,10 @@ const getInitialTheme = () => {
   return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 };
 
+const resolveBasePath = () => new URL('.', window.location.href).pathname;
+
+const resolveBaseUrl = () => `${window.location.origin}${resolveBasePath()}`;
+
 const resolveGrafanaBaseUrl = () => {
   const configured = window.__AGGREGATOR_UI__?.grafanaUrl;
   if (configured) {
@@ -68,7 +72,7 @@ const resolveGrafanaBaseUrl = () => {
   if (import.meta.env.VITE_GRAFANA_URL) {
     return import.meta.env.VITE_GRAFANA_URL;
   }
-  return `${window.location.origin}/grafana`;
+  return `${resolveBaseUrl()}grafana`;
 };
 
 const buildDashboardUrl = (baseUrl, dashboardUid, itemId, theme) => {
@@ -139,7 +143,7 @@ export default function App() {
   useEffect(() => {
     const loadCatalog = async () => {
       try {
-        const response = await fetch('/catalog.yaml');
+        const response = await fetch(new URL('catalog.yaml', resolveBaseUrl()))
         if (!response.ok) {
           throw new Error(`Failed to load catalog: ${response.status}`);
         }

--- a/compose.demo.yaml
+++ b/compose.demo.yaml
@@ -40,8 +40,9 @@ services:
 
   grafana:
     environment:
+      GF_SERVER_DOMAIN: "alivion.cc"
+      GF_SERVER_ROOT_URL: "https://aggregator.alivion.cc/grafana"
       GF_SECURITY_ALLOW_EMBEDDING: "true"
-      GF_SERVER_ROOT_URL: "%(protocol)s://%(domain)s:%(http_port)s/grafana"
       GF_SERVER_SERVE_FROM_SUB_PATH: "true"
       GF_AUTH_ANONYMOUS_ENABLED: "true"
       GF_AUTH_ANONYMOUS_ORG_ROLE: "Viewer"

--- a/deploy/demo/Caddyfile
+++ b/deploy/demo/Caddyfile
@@ -4,11 +4,6 @@
             }
 }
 
-alivion.cc, www.alivion.cc {
-    @root path /
-    redir @root /health-aggregator 302
-
-    handle /health-aggregator* {
-                                   reverse_proxy grafana:3000
-                               }
+alivion.cc, www.alivion.cc, aggregator.alivion.cc {
+    reverse_proxy aggregator-ui:3000
 }


### PR DESCRIPTION
Issue https://github.com/aleksei-sapozhnikov/aggregator/issues/63

- Migrated public access from `/health-aggregator` path to the `aggregator.alivion.cc` subdomain.
- Updated UI base URL and asset resolution to work correctly when served from a subdomain root.
- Adjusted Grafana configuration (`GF_SERVER_ROOT_URL`, domain) to match subdomain-based routing.
- Simplified Caddy routing by removing path-based redirects and proxying the subdomain directly to the UI.
- Updated README links and examples to reflect the new public URL.