### PR TITLE
Makefile: replace "per-env" commands with ENV variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,24 @@
+# ============================================================
+# Compose environment selector (single set of targets)
+#
+# Usage:
+#   make up                          # ENV defaults to local-demo
+#   make up ENV=local
+#   make rebuild-recreate ENV=demo
+#
+# Service-scoped (positional args):
+#   make restart-svc caddy grafana
+#   make rebuild-svc aggregator
+#   make recreate-svc ENV=demo caddy
+# ============================================================
+
+# ---- Environment selector ----
+SUPPORTED_ENVS := local local-demo demo
+ENV ?= local-demo
+ifeq ($(filter $(ENV),$(SUPPORTED_ENVS)),)
+  $(error Invalid ENV='$(ENV)'. Supported: $(SUPPORTED_ENVS))
+endif
+
 # ---- Compose files ----
 BASE := -f compose.yaml
 LOCAL := -f compose.local.yaml
@@ -7,14 +28,18 @@ LOCAL_PORTS := -f compose.overlay.local-ports.yaml
 DEMO_SERVICES := -f compose.overlay.demo-services.yaml
 DEMO_SERVICES_PORTS := -f compose.overlay.demo-services-local-ports.yaml
 
-LOCAL_STACK := $(BASE) $(LOCAL) $(LOCAL_PORTS)
-LOCAL_DEMO_STACK := $(BASE) $(LOCAL_DEMO) $(DEMO_SERVICES) $(LOCAL_PORTS) $(DEMO_SERVICES_PORTS)
-DEMO_STACK := $(BASE) $(DEMO) $(DEMO_SERVICES)
+STACK_local := $(BASE) $(LOCAL) $(LOCAL_PORTS)
+STACK_local-demo := $(BASE) $(LOCAL_DEMO) $(DEMO_SERVICES) $(LOCAL_PORTS) $(DEMO_SERVICES_PORTS)
+STACK_demo := $(BASE) $(DEMO) $(DEMO_SERVICES)
 
-# ---- Project names (separate stacks to avoid cross-orphan cleanup) ----
-LOCAL_PROJECT := --project-name aggregator-local
-LOCAL_DEMO_PROJECT := --project-name aggregator-local-demo
-DEMO_PROJECT := --project-name aggregator-demo
+PROJECT_local := aggregator-local
+PROJECT_local-demo := aggregator-local-demo
+PROJECT_demo := aggregator-demo
+
+STACK := $(STACK_$(ENV))
+PROJECT := $(PROJECT_$(ENV))
+
+COMPOSE_CMD :=
 
 # ---- Compose command (docker/podman autodetect; override via COMPOSE=...) ----
 COMPOSE ?=
@@ -36,21 +61,24 @@ ifeq ($(COMPOSE),)
   endif
 endif
 
-# ---- Local-only data dirs (needed by compose.local.yaml bind mounts) ----
+COMPOSE_CMD := $(COMPOSE) --project-name $(PROJECT) $(STACK)
+
+# ---- Local-only data dirs (if you still need them elsewhere) ----
 LOCAL_PROMETHEUS_DATA_DIR := ./.temp/prometheus/data
 LOCAL_GRAFANA_DATA_DIR := ./.temp/grafana/data
 
-.PHONY: help info \
+.PHONY: help info env \
         up down restart recreate rebuild rebuild-recreate clean \
-        local-up local-down local-restart local-recreate local-rebuild local-rebuild-recreate local-clean \
-        local-demo-up local-demo-down local-demo-restart local-demo-recreate local-demo-rebuild local-demo-rebuild-recreate local-demo-clean \
-        demo-up demo-down demo-restart demo-recreate demo-rebuild demo-rebuild-recreate demo-clean \
-        local-up-svc local-stop-svc local-restart-svc local-recreate-svc local-rebuild-svc local-rebuild-recreate-svc \
-        local-demo-up-svc local-demo-stop-svc local-demo-restart-svc local-demo-recreate-svc local-demo-rebuild-svc local-demo-rebuild-recreate-svc \
-        demo-up-svc demo-stop-svc demo-restart-svc demo-recreate-svc demo-rebuild-svc demo-rebuild-recreate-svc
+        up-svc stop-svc restart-svc recreate-svc rebuild-svc rebuild-recreate-svc
 
 help:
-	@echo "Conventions:"
+	@echo "Usage:"
+	@echo "  make <target> [ENV=<env>]"
+	@echo ""
+	@echo "Supported ENV values: $(SUPPORTED_ENVS)"
+	@echo "Default ENV=$(ENV)"
+	@echo ""
+	@echo "Targets:"
 	@echo "  up               -> start/update containers (no build)"
 	@echo "  down             -> stop/remove containers + network (keep volumes)"
 	@echo "  restart          -> restart existing containers (no recreate)"
@@ -59,121 +87,49 @@ help:
 	@echo "  rebuild-recreate -> build images + force re-create containers (keep volumes)"
 	@echo "  clean            -> down + remove volumes (DATA LOSS)"
 	@echo ""
-	@echo "Default (alias -> local-demo):"
-	@echo "  make up | down | restart | recreate | rebuild | rebuild-recreate | clean"
+	@echo "Service-scoped (positional args):"
+	@echo "  make restart-svc caddy grafana"
+	@echo "  make rebuild-recreate-svc ENV=demo caddy"
 	@echo ""
-	@echo "Service-scoped commands (*-svc):"
-	@echo "  Affect only one or more explicitly specified services."
-	@echo "  Other running containers in the stack are not touched."
-	@echo ""
-	@echo "  Examples:"
-	@echo "    make demo-restart-svc caddy grafana"
-	@echo "    make demo-rebuild-recreate-svc caddy"
-	@echo "    make local-demo-recreate-svc aggregator prometheus"
-	@echo ""
-	@echo "Local:"
-	@echo "  make local-up | local-down | local-restart | local-recreate | local-rebuild | local-rebuild-recreate | local-clean"
-	@echo "  make local-*-svc <svc...>"
-	@echo ""
-	@echo "Local demo:"
-	@echo "  make local-demo-up | local-demo-down | local-demo-restart | local-demo-recreate | local-demo-rebuild | local-demo-rebuild-recreate | local-demo-clean"
-	@echo "  make local-demo-*-svc <svc...>"
-	@echo ""
-	@echo "Demo (AWS / public):"
-	@echo "  make demo-up | demo-down | demo-restart | demo-recreate | demo-rebuild | demo-rebuild-recreate | demo-clean"
-	@echo "  make demo-*-svc <svc...>"
-	@echo ""
-	@echo "Variables:"
-	@echo "  COMPOSE=\"docker compose\"  Override compose command"
+	@echo "Defaults:"
+	@echo "  ENV=$(ENV)"
+
+env:
+	@echo $(SUPPORTED_ENVS)
 
 info:
 	@echo "Using compose command: $(COMPOSE)"
+	@echo "ENV=$(ENV)"
+	@echo "PROJECT=$(PROJECT)"
+	@echo "STACK=$(STACK)"
+	@echo "COMPOSE_CMD=$(COMPOSE_CMD)"
 
-# ---- default aliases ----
-# Keep existing behavior: default targets operate on local-demo.
-up: local-demo-up
-down: local-demo-down
-restart: local-demo-restart
-recreate: local-demo-recreate
-rebuild: local-demo-rebuild
-rebuild-recreate: local-demo-rebuild-recreate
-clean: local-demo-clean
+# ---- Common targets ----
+up: info
+	$(COMPOSE_CMD) up --detach --remove-orphans
 
-# ---- local ----
-local-up: info
-	$(COMPOSE) $(LOCAL_PROJECT) $(LOCAL_STACK) up --detach --remove-orphans
+down: info
+	$(COMPOSE_CMD) down --remove-orphans
 
-local-down: info
-	$(COMPOSE) $(LOCAL_PROJECT) $(LOCAL_STACK) down --remove-orphans
+restart: info
+	$(COMPOSE_CMD) restart
 
-local-restart: info
-	$(COMPOSE) $(LOCAL_PROJECT) $(LOCAL_STACK) restart
+recreate: info
+	$(COMPOSE_CMD) up --detach --force-recreate --remove-orphans
 
-local-recreate: info
-	$(COMPOSE) $(LOCAL_PROJECT) $(LOCAL_STACK) up --detach --force-recreate --remove-orphans
+rebuild: info
+	$(COMPOSE_CMD) up --detach --build --remove-orphans
 
-local-rebuild: info
-	$(COMPOSE) $(LOCAL_PROJECT) $(LOCAL_STACK) up --detach --build --remove-orphans
+rebuild-recreate: info
+	$(COMPOSE_CMD) up --detach --build --force-recreate --remove-orphans
 
-local-rebuild-recreate: info
-	$(COMPOSE) $(LOCAL_PROJECT) $(LOCAL_STACK) up --detach --build --force-recreate --remove-orphans
+clean: info
+	$(COMPOSE_CMD) down --remove-orphans --volumes
 
-local-clean: info
-	$(COMPOSE) $(LOCAL_PROJECT) $(LOCAL_STACK) down --remove-orphans --volumes
-
-# ---- local-demo ----
-local-demo-up: info
-	$(COMPOSE) $(LOCAL_DEMO_PROJECT) $(LOCAL_DEMO_STACK) up --detach --remove-orphans
-
-local-demo-down: info
-	$(COMPOSE) $(LOCAL_DEMO_PROJECT) $(LOCAL_DEMO_STACK) down --remove-orphans
-
-local-demo-restart: info
-	$(COMPOSE) $(LOCAL_DEMO_PROJECT) $(LOCAL_DEMO_STACK) restart
-
-local-demo-recreate: info
-	$(COMPOSE) $(LOCAL_DEMO_PROJECT) $(LOCAL_DEMO_STACK) up --detach --force-recreate --remove-orphans
-
-local-demo-rebuild: info
-	$(COMPOSE) $(LOCAL_DEMO_PROJECT) $(LOCAL_DEMO_STACK) up --detach --build --remove-orphans
-
-local-demo-rebuild-recreate: info
-	$(COMPOSE) $(LOCAL_DEMO_PROJECT) $(LOCAL_DEMO_STACK) up --detach --build --force-recreate --remove-orphans
-
-local-demo-clean: info
-	$(COMPOSE) $(LOCAL_DEMO_PROJECT) $(LOCAL_DEMO_STACK) down --remove-orphans --volumes
-
-# ---- demo ----
-demo-up: info
-	$(COMPOSE) $(DEMO_PROJECT) $(DEMO_STACK) up --detach --remove-orphans
-
-demo-down: info
-	$(COMPOSE) $(DEMO_PROJECT) $(DEMO_STACK) down --remove-orphans
-
-demo-restart: info
-	$(COMPOSE) $(DEMO_PROJECT) $(DEMO_STACK) restart
-
-demo-recreate: info
-	$(COMPOSE) $(DEMO_PROJECT) $(DEMO_STACK) up --detach --force-recreate --remove-orphans
-
-demo-rebuild: info
-	$(COMPOSE) $(DEMO_PROJECT) $(DEMO_STACK) up --detach --build --remove-orphans
-
-demo-rebuild-recreate: info
-	$(COMPOSE) $(DEMO_PROJECT) $(DEMO_STACK) up --detach --build --force-recreate --remove-orphans
-
-demo-clean: info
-	$(COMPOSE) $(DEMO_PROJECT) $(DEMO_STACK) down --remove-orphans --volumes
-
-# ---- service-scoped commands (positional service args) ----
-# Usage examples:
-#   make demo-restart-svc caddy grafana
-#   make local-demo-recreate-svc aggregator prometheus
-#
-SERVICE_TARGETS := \
-  local-up-svc local-stop-svc local-restart-svc local-recreate-svc local-rebuild-svc local-rebuild-recreate-svc \
-  local-demo-up-svc local-demo-stop-svc local-demo-restart-svc local-demo-recreate-svc local-demo-rebuild-svc local-demo-rebuild-recreate-svc \
-  demo-up-svc demo-stop-svc demo-restart-svc demo-recreate-svc demo-rebuild-svc demo-rebuild-recreate-svc
+# ---- Service-scoped commands (positional service args) ----
+# Positional services are passed after the target:
+#   make restart-svc caddy grafana
+SERVICE_TARGETS := up-svc stop-svc restart-svc recreate-svc rebuild-svc rebuild-recreate-svc
 
 ifneq ($(filter $(SERVICE_TARGETS),$(MAKECMDGOALS)),)
 SERVICES := $(filter-out $(SERVICE_TARGETS),$(MAKECMDGOALS))
@@ -185,77 +141,26 @@ define require_services
   $(if $(strip $(SERVICES)),,$(error No services specified. Example: make $(1) caddy grafana))
 endef
 
-# local services
-local-up-svc: info
-	$(call require_services,local-up-svc)
-	$(COMPOSE) $(LOCAL_PROJECT) $(LOCAL_STACK) up --detach --remove-orphans $(SERVICES)
+up-svc: info
+	$(call require_services,up-svc)
+	$(COMPOSE_CMD) up --detach --remove-orphans $(SERVICES)
 
-local-stop-svc: info
-	$(call require_services,local-stop-svc)
-	$(COMPOSE) $(LOCAL_PROJECT) $(LOCAL_STACK) stop $(SERVICES)
+stop-svc: info
+	$(call require_services,stop-svc)
+	$(COMPOSE_CMD) stop $(SERVICES)
 
-local-restart-svc: info
-	$(call require_services,local-restart-svc)
-	$(COMPOSE) $(LOCAL_PROJECT) $(LOCAL_STACK) restart $(SERVICES)
+restart-svc: info
+	$(call require_services,restart-svc)
+	$(COMPOSE_CMD) restart $(SERVICES)
 
-local-recreate-svc: info
-	$(call require_services,local-recreate-svc)
-	$(COMPOSE) $(LOCAL_PROJECT) $(LOCAL_STACK) up --detach --force-recreate $(SERVICES)
+recreate-svc: info
+	$(call require_services,recreate-svc)
+	$(COMPOSE_CMD) up --detach --force-recreate $(SERVICES)
 
-local-rebuild-svc: info
-	$(call require_services,local-rebuild-svc)
-	$(COMPOSE) $(LOCAL_PROJECT) $(LOCAL_STACK) up --detach --build $(SERVICES)
+rebuild-svc: info
+	$(call require_services,rebuild-svc)
+	$(COMPOSE_CMD) up --detach --build $(SERVICES)
 
-local-rebuild-recreate-svc: info
-	$(call require_services,local-rebuild-recreate-svc)
-	$(COMPOSE) $(LOCAL_PROJECT) $(LOCAL_STACK) up --detach --build --force-recreate $(SERVICES)
-
-# local-demo services
-local-demo-up-svc: info
-	$(call require_services,local-demo-up-svc)
-	$(COMPOSE) $(LOCAL_DEMO_PROJECT) $(LOCAL_DEMO_STACK) up --detach --remove-orphans $(SERVICES)
-
-local-demo-stop-svc: info
-	$(call require_services,local-demo-stop-svc)
-	$(COMPOSE) $(LOCAL_DEMO_PROJECT) $(LOCAL_DEMO_STACK) stop $(SERVICES)
-
-local-demo-restart-svc: info
-	$(call require_services,local-demo-restart-svc)
-	$(COMPOSE) $(LOCAL_DEMO_PROJECT) $(LOCAL_DEMO_STACK) restart $(SERVICES)
-
-local-demo-recreate-svc: info
-	$(call require_services,local-demo-recreate-svc)
-	$(COMPOSE) $(LOCAL_DEMO_PROJECT) $(LOCAL_DEMO_STACK) up --detach --force-recreate $(SERVICES)
-
-local-demo-rebuild-svc: info
-	$(call require_services,local-demo-rebuild-svc)
-	$(COMPOSE) $(LOCAL_DEMO_PROJECT) $(LOCAL_DEMO_STACK) up --detach --build $(SERVICES)
-
-local-demo-rebuild-recreate-svc: info
-	$(call require_services,local-demo-rebuild-recreate-svc)
-	$(COMPOSE) $(LOCAL_DEMO_PROJECT) $(LOCAL_DEMO_STACK) up --detach --build --force-recreate $(SERVICES)
-
-# demo services
-demo-up-svc: info
-	$(call require_services,demo-up-svc)
-	$(COMPOSE) $(DEMO_PROJECT) $(DEMO_STACK) up --detach --remove-orphans $(SERVICES)
-
-demo-stop-svc: info
-	$(call require_services,demo-stop-svc)
-	$(COMPOSE) $(DEMO_PROJECT) $(DEMO_STACK) stop $(SERVICES)
-
-demo-restart-svc: info
-	$(call require_services,demo-restart-svc)
-	$(COMPOSE) $(DEMO_PROJECT) $(DEMO_STACK) restart $(SERVICES)
-
-demo-recreate-svc: info
-	$(call require_services,demo-recreate-svc)
-	$(COMPOSE) $(DEMO_PROJECT) $(DEMO_STACK) up --detach --force-recreate $(SERVICES)
-
-demo-rebuild-svc: info
-	$(call require_services,demo-rebuild-svc)
-	$(COMPOSE) $(DEMO_PROJECT) $(DEMO_STACK) up --detach --build $(SERVICES)
-
-demo-rebuild-recreate-svc: info
-	$(call require_services,demo-rebuild-recreate-svc)
-	$(COMPOSE) $(DEMO_PROJECT) $(DEMO_STACK) up --detach --build --force-recreate $(SERVICES)
+rebuild-recreate-svc: info
+	$(call require_services,rebuild-recreate-svc)
+	$(COMPOSE_CMD) up --detach --build --force-recreate $(SERVICES)

--- a/deploy/demo/demo-deploy.sh
+++ b/deploy/demo/demo-deploy.sh
@@ -94,4 +94,4 @@ ssh -i ~/.ssh/demo_key \
    git fetch --prune; \
    git checkout '${DEPLOY_BRANCH}'; \
    git reset --hard 'origin/${DEPLOY_BRANCH}'; \
-   make demo-rebuild-recreate"
+   make rebuild-recreate ENV=demo"


### PR DESCRIPTION
Issue https://github.com/aleksei-sapozhnikov/aggregator/issues/78

- Introduced `ENV` selector (`local`, `local-demo`, `demo`) with validation via `SUPPORTED_ENVS`.
- Replaced duplicated environment-specific targets with dynamic `STACK_<env>` and `PROJECT_<env>` mapping.
- Implemented unified `COMPOSE_CMD` used by all lifecycle and service-scoped commands.
- Removed `local-*`, `local-demo-*`, and `demo-*` targets and simplified `.PHONY` declarations.
- Updated demo deployment script to use `make rebuild-recreate ENV=demo`.

## Result
- Eliminated large-scale duplication in the Makefile.
- Unified lifecycle interface across environments.
- Reduced maintenance complexity and risk of configuration drift.
