### PR TITLE
Simplify catalog explorer and add service search with scroll-to-node

### DIFF
--- a/services-core/aggregator-ui/src/App.jsx
+++ b/services-core/aggregator-ui/src/App.jsx
@@ -257,7 +257,7 @@ const CatalogNode = ({
     const isExpanded = expandedIds.has(node.item.id);
     const [isChildrenVisible, setIsChildrenVisible] = useState(isExpanded);
     const [isChildrenExpanded, setIsChildrenExpanded] = useState(isExpanded);
-    const timelineUrl = buildDashboardUrl(
+    buildDashboardUrl(
         grafanaBaseUrl,
         DASHBOARDS.timeline.uid,
         DASHBOARDS.timeline.slug,
@@ -359,12 +359,6 @@ const CatalogNode = ({
             </span>
                     )}
                 </div>
-            </div>
-            <div className="node-links" onClick={(event) => event.stopPropagation()}>
-                {/*        I like this link style but we don't need this link here */}
-                {/*         <a href={timelineUrl} target="_blank" rel="noreferrer"> */}
-                {/*           State Timeline */} 
-                {/*         </a> */}
             </div>
         </div>
     );

--- a/services-core/aggregator-ui/src/styles.css
+++ b/services-core/aggregator-ui/src/styles.css
@@ -317,22 +317,6 @@ body {
   color: var(--muted);
 }
 
-.node-links {
-  display: flex;
-  gap: 12px;
-  flex-wrap: wrap;
-}
-
-.node-links a {
-  font-size: 12px;
-  color: var(--link);
-  text-decoration: none;
-}
-
-.node-links a:hover {
-  text-decoration: underline;
-}
-
 .node-leaf {
   padding-left: 0;
 }


### PR DESCRIPTION
# Simplify catalog explorer and add service search with scroll-to-node

## What was done
- Replaced dual “direct/all” expand controls with a single, consistent node toggle.
- Simplified expand/collapse state logic and removed redundant synchronization refs.
- Removed unused timeline link and obsolete node-related styles.
- Added full-text search by service name, id, and type.
- Implemented ranked flat search results with status indicators.
- Auto-expand ancestor path and scroll to selected node from search results.
- Disabled tree animation during programmatic expansion to avoid visual glitches.
- Cleaned up catalog explorer structure and CSS for improved maintainability.

## Result
- Catalog explorer UI is simpler and more predictable.
- Services can be located and navigated to significantly faster via search.
- Expand/collapse behavior is easier to understand and maintain.

---

### Goal
Improve usability of the catalog explorer by simplifying expand/collapse logic and introducing search with direct navigation to services.

### Scope
- Replace dual “direct/all” expand controls with a single toggle per node.
- Remove unused timeline link and obsolete node-related styles.
- Introduce full-text search by service name, id, and type.
- Add ranked flat search results view with status indicators.
- Automatically expand ancestor path and scroll to selected node.
- Disable tree animation when expanding programmatically (e.g. from search).
- Refactor toggle logic to reduce state complexity and remove redundant sync refs.

### Out of Scope
- Changes to backend catalog model or aggregation logic.
- Modifications to Grafana dashboards or health computation.

### Definition of Done
- Catalog tree renders with a single, consistent expand/collapse control.
- Services can be searched by name, id, or type with predictable ranking.
- Selecting a search result expands the tree to the correct path and scrolls to it.
- No unused controls, links, or styles remain in the explorer.
- Application builds and works correctly in both desktop and mobile layouts.