### PR TITLE
Fix: Auto-open failing status panels

### DIFF
--- a/services-core/aggregator-ui/src/App.jsx
+++ b/services-core/aggregator-ui/src/App.jsx
@@ -772,7 +772,7 @@ export default function App() {
             text: `Health checks: ${okCount} ok, ${failingChecks.length} failing: ${failingList}`,
             failingList,
         };
-    }, [selectedChecks]);
+    }, [selectedChecks, selectedId]);
     const isSidebarOpen = isMobileLayout ? isMobileSidebarOpen : isDesktopSidebarOpen;
     const shouldOffsetContentHeader = isMobileLayout || !isSidebarOpen;
 
@@ -818,7 +818,7 @@ export default function App() {
             setIsAffectedOpen(true);
             affectedAutoOpenRef.current = false;
         }
-    }, [affectedItems.length, selectedStatus]);
+    }, [affectedItems.length, selectedId, selectedStatus]);
 
     useEffect(() => {
         if (!checksAutoOpenRef.current) {


### PR DESCRIPTION
- Fixed auto-open logic for "Affected by" panel when failing dependencies exist.
- Fixed auto-open logic for "Health checks" panel when failing checks exist.
- Updated React effect dependencies to correctly react to `selectedId` changes.

## Result
- Panels automatically expand when failures are present.
- Correct behavior when switching between catalog items.
- No manual refresh or re-selection required to see failing state.
