### PR TITLE
Limit Docker build cache size during demo deploy to prevent disk exhaustion

### DIFF
--- a/deploy/demo/demo-deploy.sh
+++ b/deploy/demo/demo-deploy.sh
@@ -94,4 +94,6 @@ ssh -i ~/.ssh/demo_key \
    git fetch --prune; \
    git checkout '${DEPLOY_BRANCH}'; \
    git reset --hard 'origin/${DEPLOY_BRANCH}'; \
+   docker image prune -f || true; \
+   docker builder prune -af --filter 'keep-storage=500MB' || true; \
    make rebuild-recreate ENV=demo"


### PR DESCRIPTION
## Summary
Add automatic Docker cleanup step in demo deployment script to prevent “No disk space” errors caused by accumulated build cache and dangling images.

## Scope
- Added `docker image prune -f` to remove dangling images before rebuild.
- Added `docker builder prune -af --filter 'keep-storage=500MB'` to limit BuildKit cache size to 500MB.
- Ensured cleanup commands are non-blocking (`|| true`) to avoid breaking deployment flow.
- Integrated cleanup into `deploy/demo/demo-deploy.sh` before `make rebuild-recreate ENV=demo`.

## Result
- Docker build cache is automatically capped at ~500MB.
- Disk usage growth during repeated demo deployments is controlled.
- Reduced risk of deployment failures due to “No disk space”.
- No impact on running containers or actively used images.
