### PR TITLE
Enable deep-link routing for catalog items with path-based resolution

### DIFF
--- a/services-core/aggregator-ui/src/App.jsx
+++ b/services-core/aggregator-ui/src/App.jsx
@@ -994,6 +994,40 @@ export default function App() {
     }, []);
 
     useEffect(() => {
+        if (!tree.length) {
+            return undefined;
+        }
+        const applySelectionFromLocation = () => {
+            const routeContext = readLocationRouteContext(basePath);
+            const resolved = resolveNodeFromLocation(tree, basePath);
+            if (!resolved) {
+                if (routeContext.hasRouteId) {
+                    normalizeUrlForRoute(routeContext.routeId, routeContext.pathIds, {replace: true});
+                }
+                return;
+            }
+            const {node} = resolved;
+            setSelectedId(node.item.id);
+            setPendingScrollId(node.uid);
+            setIsMobileSidebarOpen(false);
+            expandPathToItem(node.item.id, {suppressAnimation: true, path: node.path});
+            if (routeContext.hasRouteId || routeContext.hasPathParam) {
+                updateUrlForNode(node, {replace: true});
+            }
+        };
+
+        applySelectionFromLocation();
+
+        const handlePopState = () => {
+            applySelectionFromLocation();
+        };
+        window.addEventListener('popstate', handlePopState);
+        return () => {
+            window.removeEventListener('popstate', handlePopState);
+        };
+    }, [basePath, expandPathToItem, normalizeUrlForRoute, tree, updateUrlForNode]);
+
+    useEffect(() => {
         setIsAffectedOpen(false);
         affectedAutoOpenRef.current = true;
         setIsChecksOpen(false);


### PR DESCRIPTION
- Added URL-based routing for catalog item selection using `/item/{id}` pattern.
- Introduced support for hierarchical `path` query parameter to resolve items within deep catalog trees.
- Extended catalog tree nodes with explicit `path` metadata to enable deterministic route resolution.
- Implemented location parsing and normalization logic (including base path handling and history integration).
- Synced UI state with browser history (`pushState`, `replaceState`, `popstate`) to support direct links and back/forward navigation.

## Result
- Any catalog item can now be opened directly via URL.
- Deeply nested services resolve correctly even in complex hierarchies.
- Browser navigation (back/forward) keeps UI state consistent.
- URLs are normalized automatically to prevent broken or ambiguous routes.
