### PR TITLE
Sync Grafana iframe background with UI theme (light/dark)

### DIFF
--- a/services-core/aggregator-ui/public/grafana-frame.html
+++ b/services-core/aggregator-ui/public/grafana-frame.html
@@ -11,7 +11,12 @@
             width: 100%;
             height: 100%;
             overflow: hidden;
-            background: transparent;
+            background: #ffffff;
+        }
+
+        html[data-theme='dark'],
+        body[data-theme='dark'] {
+            background: #181b1f;
         }
 
         #grafana-embed {
@@ -19,6 +24,7 @@
             height: 100%;
             border: 0;
             display: block;
+            background: transparent;
         }
     </style>
 </head>
@@ -29,7 +35,14 @@
         const params = new URLSearchParams(window.location.search);
         const srcParam = params.get('src');
         const initialTarget = srcParam ? decodeURIComponent(srcParam) : '';
+        const themeParam = params.get('theme');
         const iframe = document.getElementById('grafana-embed');
+
+        const applyTheme = (value) => {
+            const nextTheme = value === 'dark' ? 'dark' : 'light';
+            document.documentElement.dataset.theme = nextTheme;
+            document.body.dataset.theme = nextTheme;
+        };
 
         const applyTarget = (target) => {
             if (!target) {
@@ -70,12 +83,20 @@
         });
 
         iframe.src = 'about:blank';
+        applyTheme(themeParam);
         if (initialTarget) {
             applyTarget(initialTarget);
         }
 
         window.addEventListener('message', (event) => {
-            if (!event.data || event.data.type !== 'set-grafana-src') {
+            if (!event.data) {
+                return;
+            }
+            if (event.data.type === 'set-frame-theme') {
+                applyTheme(event.data.theme);
+                return;
+            }
+            if (event.data.type !== 'set-grafana-src') {
                 return;
             }
             const nextSrc = event.data.src;

--- a/services-core/aggregator-ui/src/App.jsx
+++ b/services-core/aggregator-ui/src/App.jsx
@@ -537,6 +537,7 @@ export default function App() {
     const [selectedId, setSelectedId] = useState('');
     const [error, setError] = useState('');
     const [theme, setTheme] = useState(getInitialTheme);
+    const initialFrameThemeRef = useRef(theme);
     const [expandedIds, setExpandedIds] = useState(() => new Set());
     const [itemStatuses, setItemStatuses] = useState({});
     const [itemCheckDown, setItemCheckDown] = useState({});
@@ -684,6 +685,10 @@ export default function App() {
         }
         try {
             grafanaFrameReadyRef.current = true;
+            iframe.contentWindow.postMessage(
+                {type: 'set-frame-theme', theme},
+                window.location.origin,
+            );
             if (pendingGrafanaSrcRef.current) {
                 iframe.contentWindow.postMessage(
                     {type: 'set-grafana-src', src: pendingGrafanaSrcRef.current},
@@ -711,7 +716,7 @@ export default function App() {
         } catch (error) {
             // Ignore cross-origin access issues when Grafana is hosted elsewhere.
         }
-    }, []);
+    }, [theme]);
 
     useEffect(
         () => () => {
@@ -727,6 +732,17 @@ export default function App() {
     useEffect(() => {
         document.body.dataset.theme = theme;
         localStorage.setItem('aggregator-ui-theme', theme);
+    }, [theme]);
+
+    useEffect(() => {
+        const iframe = grafanaIframeRef.current;
+        if (!iframe?.contentWindow || !grafanaFrameReadyRef.current) {
+            return;
+        }
+        iframe.contentWindow.postMessage(
+            {type: 'set-frame-theme', theme},
+            window.location.origin,
+        );
     }, [theme]);
 
     useEffect(() => {
@@ -1057,6 +1073,7 @@ export default function App() {
 
     const buildGrafanaFrameUrl = useCallback((grafanaUrl) => {
         const frameUrl = new URL('grafana-frame.html', resolveBaseUrl());
+        frameUrl.searchParams.set('theme', initialFrameThemeRef.current);
         if (grafanaUrl) {
             frameUrl.searchParams.set('src', encodeURIComponent(grafanaUrl));
         }
@@ -1273,7 +1290,7 @@ export default function App() {
                 {type: 'set-grafana-src', src: dashboardUrl},
                 window.location.origin,
             );
-            return;
+
         }
     }, [grafanaBaseUrl, selectedItem, theme]);
 

--- a/services-core/aggregator-ui/src/styles.css
+++ b/services-core/aggregator-ui/src/styles.css
@@ -470,6 +470,7 @@ body {
   flex: 1;
   width: 100%;
   border: none;
+  background: var(--panel);
 }
 
 .affected-panel {


### PR DESCRIPTION
- Set explicit light and dark backgrounds inside `grafana-frame.html` instead of using transparent root background
- Introduced `data-theme` handling in iframe document (`html` and `body`) to support theme switching
- Added `set-frame-theme` postMessage API to dynamically update iframe theme without reload
- Passed initial theme as query parameter when constructing `grafana-frame.html` URL
- Propagated theme changes from `App.jsx` to iframe via `postMessage` on theme updates
- Ensured iframe container background aligns with panel background in main UI styles

## Result
- Grafana iframe background visually matches selected UI theme (light or dark).  
- Theme switches are applied immediately without iframe reload.  
- Eliminated visual mismatch and flashing caused by transparent iframe background.