### PR TITLE
Remove redundant divider in sidebar header

### DIFF
--- a/services-core/aggregator-ui/src/styles.css
+++ b/services-core/aggregator-ui/src/styles.css
@@ -123,9 +123,6 @@ body {
 
 .sidebar-header {
   min-height: 40px;
-  border-bottom: 1px solid var(--border);
-  margin-left: 56px;
-  margin-bottom: 12px;
 }
 
 .hamburger-toggle {


### PR DESCRIPTION
- Removed bottom border from `.sidebar-header` that visually separated logo controls from search block.
- Eliminated extra spacing related to the header divider.
- Simplified sidebar visual hierarchy for a cleaner layout.

## Result
- Logo and search controls now feel visually unified.
- Sidebar appearance is cleaner and less fragmented.
- No functional changes to sidebar behavior.