### PR TITLE
Fix docker builder prune command on Demo deploy script

### DIFF
--- a/deploy/demo/demo-deploy.sh
+++ b/deploy/demo/demo-deploy.sh
@@ -95,5 +95,5 @@ ssh -i ~/.ssh/demo_key \
    git checkout '${DEPLOY_BRANCH}'; \
    git reset --hard 'origin/${DEPLOY_BRANCH}'; \
    docker image prune -f || true; \
-   docker builder prune -af --filter 'keep-storage=500MB' || true; \
+   docker builder prune -af --filter keep-storage=500MB || true; \
    make rebuild-recreate ENV=demo"


### PR DESCRIPTION
To fix the error which is most likely due to using unary quotes:

> ERROR: rpc error: code = Unknown desc = failed to parse prune filters [keep-storage==500MB]: filters: parse error: [keep >|-|< storage==500MB]: expected an operator ("=="|"!="|"~="): invalid argument