### PR TITLE
Fix docker builder prune command on Demo deploy script

### DIFF
--- a/deploy/demo/demo-deploy.sh
+++ b/deploy/demo/demo-deploy.sh
@@ -95,5 +95,5 @@ ssh -i ~/.ssh/demo_key \
    git checkout '${DEPLOY_BRANCH}'; \
    git reset --hard 'origin/${DEPLOY_BRANCH}'; \
    docker image prune -f || true; \
-   docker builder prune -af --filter keep-storage=500MB || true; \
+   docker builder prune -af --keep-storage 500m || true; \
    make rebuild-recreate ENV=demo"


### PR DESCRIPTION
Next try after https://github.com/aleksei-sapozhnikov/aggregator/pull/109

According to [docker docs](https://docs.docker.com/reference/cli/docker/builder/prune/) it has separate `--keep-storage` parameter.

**UPD**: yes, that worked.