### PR TITLE
Improve health checks panel summary and display names

### DIFF
--- a/services-core/aggregator-ui/src/App.jsx
+++ b/services-core/aggregator-ui/src/App.jsx
@@ -1010,18 +1010,21 @@ export default function App() {
     const checkSummary = useMemo(() => {
         const okCount = selectedChecks.filter((check) => check.status === 'up').length;
         const failingChecks = selectedChecks.filter((check) => check.status === 'down');
-        if (failingChecks.length === 0) {
-            return {
-                text: `Health checks: ${okCount} ok`,
-                failingList: '',
-            };
-        }
-        const failingList = failingChecks.map((check) => check.name || check.id).join(', ');
         return {
-            text: `Health checks: ${okCount} ok, ${failingChecks.length} failing: ${failingList}`,
-            failingList,
+            okCount,
+            failingCount: failingChecks.length,
+            failingList: failingChecks.map((check) => check.name || check.id).join(', '),
         };
-    }, [selectedChecks, selectedId]);
+    }, [selectedChecks]);
+    const checksSummaryText = useMemo(() => {
+        const baseText = `Health checks: ${checkSummary.okCount} ok${
+            checkSummary.failingCount > 0 ? `, ${checkSummary.failingCount} failing` : ''
+        }`;
+        if (isChecksOpen || checkSummary.failingCount === 0) {
+            return baseText;
+        }
+        return `${baseText}: ${checkSummary.failingList}`;
+    }, [checkSummary, isChecksOpen]);
     const isSidebarOpen = isMobileLayout ? isMobileSidebarOpen : isDesktopSidebarOpen;
     const shouldOffsetContentHeader = isMobileLayout || !isSidebarOpen;
     const homeHref = basePath || '/';
@@ -1607,7 +1610,7 @@ export default function App() {
                                         ›
                                     </span>
                                     <span className={`affected-summary ${isChecksOpen ? 'is-open' : ''}`}>
-                                        {checkSummary.text}
+                                        {checksSummaryText}
                                     </span>
                                 </button>
                                 {isChecksOpen && (


### PR DESCRIPTION
- Use `check_name` (fallback to `check_id`) when building health check list from Prometheus metrics.
- Store and display human-readable check names in the checks panel instead of raw IDs.
- Sort checks by name (fallback to ID) for more natural ordering.
- Refactor summary logic to separate counts from rendered text.
- Adjust collapsed vs expanded summary text:
  - Collapsed: show failing check names inline.
  - Expanded: show clean count-only summary.

## Result
- Health checks panel is easier to read and more user-friendly.
- Failing checks are clearly identified by descriptive names.
- Summary text behaves consistently depending on panel state.
- No changes to underlying health evaluation logic.