### PR TITLE
Fix initial routing sync and preserve tree expansion on history navigation

### DIFF
--- a/services-core/aggregator-ui/src/App.jsx
+++ b/services-core/aggregator-ui/src/App.jsx
@@ -429,14 +429,6 @@ const CatalogNode = ({
                      }) => {
     const hasChildren = node.children.length > 0;
     const isExpanded = expandedIds.has(node.item.id);
-    buildDashboardUrl(
-        grafanaBaseUrl,
-        DASHBOARDS.timeline.uid,
-        DASHBOARDS.timeline.slug,
-        node.item.id,
-        theme,
-        DASHBOARDS.timeline.panelId,
-    );
     const statusLabel = `Status: ${status.toUpperCase()}${
         lastUpdated ? ` (at ${lastUpdated})` : ''
     }`;


### PR DESCRIPTION
- Removed unused `buildDashboardUrl` invocation to eliminate redundant logic.
- Fixed selection sync with browser history (`popstate`) to correctly restore selected item.
- Introduced `ensurePathExpanded` to expand only missing ancestors when restoring selection.
- Preserved existing tree expansion state during back/forward navigation.
- Improved fallback selection logic when route does not resolve to a valid node.
- Reduced unnecessary sidebar closing and animation during history-based navigation.

## Result
- Direct navigation and page refresh correctly select the intended catalog item.
- Browser back/forward restores selection without collapsing unrelated branches.
- Tree expansion behavior feels stable and predictable.
- Cleaner routing logic with removed dead code.