### PR TITLE
[Demo] Redirect root domain to aggregator subdomain

### DIFF
--- a/deploy/demo/Caddyfile
+++ b/deploy/demo/Caddyfile
@@ -4,6 +4,10 @@
     }
 }
 
-alivion.cc, www.alivion.cc, aggregator.alivion.cc {
+alivion.cc {
+    redir https://aggregator.alivion.cc{uri} permanent
+}
+
+www.alivion.cc, aggregator.alivion.cc {
     reverse_proxy aggregator-ui:3000
 }


### PR DESCRIPTION
- Configured `alivion.cc` to permanently redirect to `https://aggregator.alivion.cc`.
- Separated root domain handling from `www` and subdomain reverse proxy configuration.
- Kept `www.alivion.cc` and `aggregator.alivion.cc` pointing directly to `aggregator-ui`.