### PR TITLE
Reorganize and extend .gitignore for multi-stack project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,37 +1,107 @@
-# IDEA config
+# =========================
+# OS / System files
+# =========================
+.DS_Store
+Thumbs.db
+desktop.ini
+
+# =========================
+# IDE / Editor
+# =========================
+
+## IntelliJ IDEA
 .idea/
 *.iml
+out/
 
-# Temporary files, usually for local dev
-.temp/
+## VS Code
+.vscode/
 
-# Build artifacts
+## Eclipse
+.project
+.classpath
+.settings/
+
+# =========================
+# Java / Maven
+# =========================
+
+# Build output
 target/
 
-# Compiled class file
+# Compiled classes
 *.class
 
-# Log file
-*.log
-
-# BlueJ files
-*.ctxt
-
-# Mobile Tools for Java (J2ME)
-.mtj.tmp/
-
-# Package Files #
+# Packaged artifacts
 *.jar
 *.war
-*.nar
 *.ear
-*.zip
-*.tar.gz
-*.rar
+*.nar
 
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+# Logs
+*.log
+
+# JVM crash logs
 hs_err_pid*
 replay_pid*
 
-# Python venv
-.venv
+# =========================
+# Python
+# =========================
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Bytecode
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+
+# Tool caches
+.pytest_cache/
+.mypy_cache/
+.coverage
+.coverage.*
+htmlcov/
+
+# =========================
+# Node / Frontend
+# =========================
+
+# Dependencies
+node_modules/
+
+# Package manager logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Build output
+dist/
+build/
+.vite/
+
+# =========================
+# Temporary / Local Dev
+# =========================
+.temp/
+tmp/
+*.tmp
+
+# =========================
+# Archives (optional)
+# =========================
+*.zip
+*.tar
+*.tar.gz
+*.rar
+
+# =========================
+# Misc
+# =========================
+*.ctxt
+.mtj.tmp/


### PR DESCRIPTION
- Restructured `.gitignore` into clearly grouped sections (OS, IDE, Java, Python, Node, temp, archives).
- Added missing ignores for:
    - IntelliJ, VS Code, Eclipse artifacts.
    - Python virtual environments and tool caches.
    - Node modules, build outputs, and package manager logs.
    - Additional Java build artifacts and crash logs.
- Normalized formatting and removed duplicated or scattered entries.

## Result
- Cleaner and more maintainable `.gitignore`.
- Better coverage for Java, Python, and frontend tooling used in the project.
- Reduced risk of accidentally committing local or build-generated files.