### PR TITLE
Separate expand toggle from selection in catalog tree

### DIFF
--- a/services-core/aggregator-ui/src/App.jsx
+++ b/services-core/aggregator-ui/src/App.jsx
@@ -437,55 +437,57 @@ const CatalogNode = ({
         <div
             className={`node-row ${selectedId === node.item.id ? 'is-selected' : ''}`}
             data-node-id={node.uid}
-            onClick={() => onSelect(node)}
-            role="button"
-            tabIndex={0}
-            onKeyDown={(event) => {
-                if (event.key === 'Enter' || event.key === ' ') {
-                    event.preventDefault();
-                    onSelect(node);
-                }
-            }}
         >
-            <div className="node-main">
-                {hasChildren ? (
-                    <button
-                        className={`node-toggle ${isExpanded ? 'is-expanded' : ''}`}
-                        type="button"
-                        aria-label={isExpanded ? 'Collapse children' : 'Expand children'}
-                        title={isExpanded ? 'Collapse children' : 'Expand children'}
-                        onClick={(event) => {
-                            event.stopPropagation();
-                            onToggleNode(node);
-                        }}
-                    >
-                        <span
-                            className={`affected-chevron ${isExpanded ? 'is-open' : ''}`}
-                            aria-hidden="true"
-                        >
-                            ›
-                        </span>
-                    </button>
-                ) : (
-                    <span className="node-toggle-spacer" aria-hidden="true"/>
-                )}
-                <div
-                    className="node-label"
+            {hasChildren ? (
+                <button
+                    className={`node-toggle-column ${isExpanded ? 'is-expanded' : ''}`}
+                    type="button"
+                    aria-label={isExpanded ? 'Collapse children' : 'Expand children'}
+                    title={isExpanded ? 'Collapse children' : 'Expand children'}
+                    onClick={(event) => {
+                        event.stopPropagation();
+                        onToggleNode(node);
+                    }}
                 >
-          <span className="node-heading">
-            <span
-                className={`status-indicator status-${status}`}
-                aria-label={statusLabel}
-                title={statusLabel}
-            />
-              {node.item.name && <span className="node-name">{node.item.name}</span>}
-          </span>
-                    {(node.item.id || node.item.type) && (
-                        <span className="node-identity">
-              {node.item.id}
-                            {node.item.type ? ` (${node.item.type})` : ''}
-            </span>
-                    )}
+                    <span
+                        className={`affected-chevron ${isExpanded ? 'is-open' : ''}`}
+                        aria-hidden="true"
+                    >
+                        ›
+                    </span>
+                </button>
+            ) : (
+                <span className="node-toggle-column node-toggle-spacer" aria-hidden="true"/>
+            )}
+            <div
+                className="node-content"
+                onClick={() => onSelect(node)}
+                role="button"
+                tabIndex={0}
+                onKeyDown={(event) => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                        event.preventDefault();
+                        onSelect(node);
+                    }
+                }}
+            >
+                <div className="node-main">
+                    <div className="node-label">
+                      <span className="node-heading">
+                        <span
+                            className={`status-indicator status-${status}`}
+                            aria-label={statusLabel}
+                            title={statusLabel}
+                        />
+                          {node.item.name && <span className="node-name">{node.item.name}</span>}
+                      </span>
+                        {(node.item.id || node.item.type) && (
+                            <span className="node-identity">
+                          {node.item.id}
+                                {node.item.type ? ` (${node.item.type})` : ''}
+                        </span>
+                        )}
+                    </div>
                 </div>
             </div>
         </div>
@@ -1438,43 +1440,45 @@ export default function App() {
                                             className={`node-row ${selectedId === item.id ? 'is-selected' : ''}`}
                                             data-node-id={item.id}
                                         >
-                                            <div className="node-main">
-                                                <span className="node-toggle-spacer" aria-hidden="true"/>
-                                                <div
-                                                    className="node-label"
-                                                    onClick={(event) => {
-                                                        event.stopPropagation();
+                                            <span className="node-toggle-column node-toggle-spacer" aria-hidden="true"/>
+                                            <div
+                                                className="node-content"
+                                                onClick={(event) => {
+                                                    event.stopPropagation();
+                                                    handleSelectItemById(item.id);
+                                                    expandPathToItem(item.id, {suppressAnimation: true});
+                                                }}
+                                                role="button"
+                                                tabIndex={0}
+                                                onKeyDown={(event) => {
+                                                    if (event.key === 'Enter' || event.key === ' ') {
+                                                        event.preventDefault();
                                                         handleSelectItemById(item.id);
                                                         expandPathToItem(item.id, {suppressAnimation: true});
-                                                    }}
-                                                    role="button"
-                                                    tabIndex={0}
-                                                    onKeyDown={(event) => {
-                                                        if (event.key === 'Enter' || event.key === ' ') {
-                                                            event.preventDefault();
-                                                            handleSelectItemById(item.id);
-                                                            expandPathToItem(item.id, {suppressAnimation: true});
-                                                        }
-                                                    }}
-                                                >
-                          <span className="node-heading">
-                            <span
-                                className={`status-indicator status-${itemStatuses[item.id] || 'unknown'}`}
-                                aria-label={`Status: ${(itemStatuses[item.id] || 'unknown').toUpperCase()}${
-                                    lastUpdated ? ` (at ${lastUpdated})` : ''
-                                }`}
-                                title={`Status: ${(itemStatuses[item.id] || 'unknown').toUpperCase()}${
-                                    lastUpdated ? ` (at ${lastUpdated})` : ''
-                                }`}
-                            />
-                              {item.name && <span className="node-name">{item.name}</span>}
-                          </span>
-                                                    {(item.id || item.type) && (
-                                                        <span className="node-identity">
-                              {item.id}
-                                                            {item.type ? ` (${item.type})` : ''}
-                            </span>
-                                                    )}
+                                                    }
+                                                }}
+                                            >
+                                                <div className="node-main">
+                                                    <div className="node-label">
+                                                      <span className="node-heading">
+                                                        <span
+                                                            className={`status-indicator status-${itemStatuses[item.id] || 'unknown'}`}
+                                                            aria-label={`Status: ${(itemStatuses[item.id] || 'unknown').toUpperCase()}${
+                                                                lastUpdated ? ` (at ${lastUpdated})` : ''
+                                                            }`}
+                                                            title={`Status: ${(itemStatuses[item.id] || 'unknown').toUpperCase()}${
+                                                                lastUpdated ? ` (at ${lastUpdated})` : ''
+                                                            }`}
+                                                        />
+                                                          {item.name && <span className="node-name">{item.name}</span>}
+                                                      </span>
+                                                        {(item.id || item.type) && (
+                                                            <span className="node-identity">
+                                                          {item.id}
+                                                                {item.type ? ` (${item.type})` : ''}
+                                                        </span>
+                                                        )}
+                                                    </div>
                                                 </div>
                                             </div>
                                         </div>

--- a/services-core/aggregator-ui/src/styles.css
+++ b/services-core/aggregator-ui/src/styles.css
@@ -404,25 +404,17 @@ body {
 
 .node-row {
   display: flex;
-  flex-direction: column;
-  gap: 6px;
-  padding: 10px 12px;
+  align-items: stretch;
+  gap: 0;
+  padding: 0;
   border-radius: 10px;
   background: var(--panel-alt);
   border: 1px solid transparent;
-  cursor: pointer;
 }
 
-.node-main {
-  display: flex;
-  align-items: flex-start;
-  gap: 8px;
-}
-
-.node-toggle {
-  width: 18px;
-  height: 18px;
-  border-radius: 999px;
+.node-toggle-column {
+  width: 32px;
+  min-width: 32px;
   border: none;
   background: transparent;
   color: var(--muted);
@@ -430,18 +422,45 @@ body {
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  flex: 0 0 auto;
-  transition: color 150ms ease;
+  padding: 10px 0;
+  border-radius: 10px 0 0 10px;
+  transition: color 150ms ease, background 150ms ease;
 }
 
-.node-toggle.is-expanded {
+.node-toggle-column:hover {
+  background: var(--panel-hover);
+}
+
+.node-toggle-column.is-expanded {
   color: var(--text);
 }
 
-.node-toggle-spacer {
-  width: 18px;
-  height: 18px;
-  flex: 0 0 auto;
+.node-toggle-column.node-toggle-spacer {
+  cursor: default;
+  background: transparent;
+}
+
+.node-toggle-column.node-toggle-spacer:hover {
+  background: transparent;
+}
+
+.node-content {
+  flex: 1 1 auto;
+  padding: 10px 12px;
+  display: flex;
+  align-items: flex-start;
+  cursor: pointer;
+}
+
+.node-content:hover {
+  background: var(--panel-hover);
+  border-radius: 0 10px 10px 0;
+}
+
+.node-main {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
 }
 
 .node-row.is-selected {
@@ -502,8 +521,9 @@ body {
 }
 
 .node-label:focus-visible,
+.node-content:focus-visible,
+.node-toggle-column:focus-visible,
 .tree-controls button:focus-visible,
-.node-toggle:focus-visible,
 .tree-search input:focus-visible,
 .search-clear:focus-visible,
 .theme-toggle:focus-visible,


### PR DESCRIPTION
- Split tree row into two distinct interaction areas:
  - Dedicated toggle column for expand/collapse.
  - Separate content area for item selection.
- Removed row-level click handler to prevent accidental selection when expanding.
- Improved keyboard accessibility for both toggle and content areas.
- Refactored markup structure to better reflect interaction semantics.
- Updated styles:
  - Introduced `.node-toggle-column` and `.node-content`.
  - Adjusted hover, focus, and selected states.
  - Improved visual separation between toggle and content zones.

## Result
- Expanding and selecting items no longer conflict.
- Tree interaction feels more precise and predictable.
- Accessibility and focus handling improved.
- Cleaner visual and structural separation of responsibilities inside each row.