### PR TITLE
Fix mobile sidebar closing during search input

### DIFF
--- a/services-core/aggregator-ui/src/App.jsx
+++ b/services-core/aggregator-ui/src/App.jsx
@@ -1142,7 +1142,7 @@ export default function App() {
                     return;
                 }
                 if (!routeContext.hasPathParam) {
-                    const fallbackNode = filteredTree[0] || null;
+                    const fallbackNode = tree[0] || null;
                     const fallbackId = fallbackNode?.item?.id || '';
                     setSelectedId(fallbackId);
                     setPendingScrollId(fallbackNode?.uid || '');
@@ -1194,7 +1194,6 @@ export default function App() {
         basePath,
         ensurePathExpanded,
         expandPathToItem,
-        filteredTree,
         normalizeUrlForRoute,
         tree,
         updateUrlForItemId,


### PR DESCRIPTION
# Fix mobile sidebar closing during search input

- Fixed fallback selection logic to use full tree instead of filtered search results.
- Prevented unintended selection reset when search query changes.
- Removed `filteredTree` dependency from routing effect to avoid unnecessary re-runs.

## Result
- Sidebar no longer closes on mobile when typing the first character in search.
- Search input behaves independently from selection routing.
- Mobile catalog navigation feels stable and predictable.