### PR TITLE
Grafana - rename "failing_only" filter to “graphs” and improve requests

### DIFF
--- a/services-extra/grafana/dashboards/item_health_state.json
+++ b/services-extra/grafana/dashboards/item_health_state.json
@@ -171,7 +171,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "(\n  (\n    (\n      (catalog_item_check_state{item_id=~\"${item_id:regex}\"} and on() (vector(${graphs}) == 0))\n      or (catalog_item_check_state{item_id=~\"${item_id:regex}\"} and on(item_id,check_id,check_source) (min_over_time(catalog_item_check_state{item_id=~\"${item_id:regex}\"}[$__range] @ end()) < 1) and on() (vector(${graphs}) == 1))\n    )\n    or (\n      (catalog_item_check_state{item_id=~\"${deps:regex}\"} and on() (vector(${graphs}) == 0))\n      or (catalog_item_check_state{item_id=~\"${deps:regex}\"} and on(item_id,check_id,check_source) (min_over_time(catalog_item_check_state{item_id=~\"${deps:regex}\"}[$__range] @ end()) < 1) and on() (vector(${graphs}) == 1))\n    )\n  ) and on() (vector(${healthchecks}) == 2)\n  or (\n    (catalog_item_check_state{item_id=~\"${item_id:regex}\"} and on() (vector(${graphs}) == 0))\n    or (catalog_item_check_state{item_id=~\"${item_id:regex}\"} and on(item_id,check_id,check_source) (min_over_time(catalog_item_check_state{item_id=~\"${item_id:regex}\"}[$__range] @ end()) < 1) and on() (vector(${graphs}) == 1))\n  ) and on() (vector(${healthchecks}) == 1)\n)",
+          "expr": "(\n  (\n    (catalog_item_check_state{item_id=~\"${item_id:regex}\"} and on() (vector(${graphs}) == 0))\n    or (\n      catalog_item_check_state{item_id=~\"${item_id:regex}\"}\n      and on(item_id,check_id,check_source) (min_over_time(catalog_item_check_state{item_id=~\"${item_id:regex}\"}[$__range] @ end()) < 1)\n      and on() (vector(${graphs}) == 1)\n    )\n  )\n  and on() (vector(${healthchecks}) >= 1)\n)",
           "legendFormat": "\u200b\u200b[check] {{check_name}}",
           "range": true,
           "refId": "C"
@@ -182,7 +182,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "(\n  (catalog_item_check_state{item_id=~\"${deps:regex}\"} and on() (vector(${graphs}) == 0))\n  or (catalog_item_check_state{item_id=~\"${deps:regex}\"} and on(item_id,check_id,check_source) (min_over_time(catalog_item_check_state{item_id=~\"${deps:regex}\"}[$__range] @ end()) < 1) and on() (vector(${graphs}) == 1))\n) and on() (vector(${healthchecks}) == 2)",
+          "expr": "(\n  (\n    (catalog_item_check_state{item_id=~\"${deps:regex}\"} and on() (vector(${graphs}) == 0))\n    or (\n      catalog_item_check_state{item_id=~\"${deps:regex}\"}\n      and on(item_id,check_id,check_source) (min_over_time(catalog_item_check_state{item_id=~\"${deps:regex}\"}[$__range] @ end()) < 1)\n      and on() (vector(${graphs}) == 1)\n    )\n  )\n  and on() (vector(${healthchecks}) == 2)\n)",
           "legendFormat": "\u200b\u200b[check] {{check_name}}",
           "range": true,
           "refId": "D"


### PR DESCRIPTION
- Renamed Grafana variable from `failing_only` to `graphs`.
- Replaced boolean-style options (`true/false`) with user-facing labels:
  - `all`
  - `failing only`
- Updated all PromQL expressions to use the new `${graphs}` variable.
- Refined check queries to clearly separate:
  - Own item checks.
  - Dependency checks.
- Adjusted panel overrides and conditions to reflect the new variable semantics.

## Result
- Timeline filter control is clearer and more aligned with what is actually displayed.
- Cleaner separation between own and dependency health checks in the visualization.
- More readable and maintainable dashboard configuration.