### PR TITLE
Add flexible item/check filters and clarify timeline legends

### DIFF
--- a/services-extra/grafana/dashboards/item_health_state.json
+++ b/services-extra/grafana/dashboards/item_health_state.json
@@ -147,7 +147,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "catalog_item_state{item_id=~\"${cur_item_id:regex}\"} and on() ((vector(${items}) == 1) or (vector(${items}) == 2))",
+          "expr": "catalog_item_state{item_id=~\"${item_id:regex}\"} and on() ((vector(${items}) == 1) or (vector(${items}) == 2))",
           "hide": false,
           "instant": false,
           "legendFormat": "[cur it] {{item_name}}",
@@ -160,7 +160,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "(\n  (\n    (catalog_item_check_state{item_id=~\"${cur_item_id:regex}\"} and on() (vector(${graphs}) == 0))\n    or (\n      catalog_item_check_state{item_id=~\"${cur_item_id:regex}\"}\n      and on(item_id,check_id,check_source) (min_over_time(catalog_item_check_state{item_id=~\"${cur_item_id:regex}\"}[$__range] @ end()) < 1)\n      and on() (vector(${graphs}) == 1)\n    )\n  )\n  and on() ((vector(${hchecks}) == 1) or (vector(${hchecks}) == 2))\n)",
+          "expr": "(\n  (\n    (catalog_item_check_state{item_id=~\"${item_id:regex}\"} and on() (vector(${graphs}) == 0))\n    or (\n      catalog_item_check_state{item_id=~\"${item_id:regex}\"}\n      and on(item_id,check_id,check_source) (min_over_time(catalog_item_check_state{item_id=~\"${item_id:regex}\"}[$__range] @ end()) < 1)\n      and on() (vector(${graphs}) == 1)\n    )\n  )\n  and on() ((vector(${hchecks}) == 1) or (vector(${hchecks}) == 2))\n)",
           "legendFormat": "\u200b[cur hc] {{check_name}} ({{item_name}})",
           "range": true,
           "refId": "C"
@@ -171,7 +171,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "(\n  (catalog_item_own_state{item_id=~\"${dep_item_ids:regex}\"} and on() (vector(${graphs}) == 0))\n  or (catalog_item_own_state{item_id=~\"${dep_item_ids:regex}\"} and on(item_id) (min_over_time(catalog_item_own_state{item_id=~\"${dep_item_ids:regex}\"}[$__range] @ end()) < 1) and on() (vector(${graphs}) == 1))\n) and on() ((vector(${items}) == 2) or (vector(${items}) == 3))",
+          "expr": "(\n  (catalog_item_own_state{item_id=~\"${deps:regex}\"} and on() (vector(${graphs}) == 0))\n  or (catalog_item_own_state{item_id=~\"${deps:regex}\"} and on(item_id) (min_over_time(catalog_item_own_state{item_id=~\"${deps:regex}\"}[$__range] @ end()) < 1) and on() (vector(${graphs}) == 1))\n) and on() ((vector(${items}) == 2) or (vector(${items}) == 3))",
           "legendFormat": "\u200c[dep it] {{item_name}}",
           "range": true,
           "refId": "B"
@@ -182,7 +182,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "(\n  (\n    (catalog_item_check_state{item_id=~\"${dep_item_ids:regex}\"} and on() (vector(${graphs}) == 0))\n    or (\n      catalog_item_check_state{item_id=~\"${dep_item_ids:regex}\"}\n      and on(item_id,check_id,check_source) (min_over_time(catalog_item_check_state{item_id=~\"${dep_item_ids:regex}\"}[$__range] @ end()) < 1)\n      and on() (vector(${graphs}) == 1)\n    )\n  )\n  and on() ((vector(${hchecks}) == 2) or (vector(${hchecks}) == 3))\n)",
+          "expr": "(\n  (\n    (catalog_item_check_state{item_id=~\"${deps:regex}\"} and on() (vector(${graphs}) == 0))\n    or (\n      catalog_item_check_state{item_id=~\"${deps:regex}\"}\n      and on(item_id,check_id,check_source) (min_over_time(catalog_item_check_state{item_id=~\"${deps:regex}\"}[$__range] @ end()) < 1)\n      and on() (vector(${graphs}) == 1)\n    )\n  )\n  and on() ((vector(${hchecks}) == 2) or (vector(${hchecks}) == 3))\n)",
           "legendFormat": "\u200d[dep hc] {{check_name}}",
           "range": true,
           "refId": "D"
@@ -210,7 +210,7 @@
         "definition": "label_values(catalog_item_state, item_id)",
         "hide": 2,
         "includeAll": false,
-        "name": "cur_item_id",
+        "name": "item_id",
         "options": [],
         "query": {
           "query": "label_values(catalog_item_state, item_id)",
@@ -364,7 +364,7 @@
           "type": "prometheus",
           "uid": "prometheus"
         },
-        "definition": "label_values(catalog_dependency{source_id=\"$cur_item_id\"}, target_id)",
+        "definition": "label_values(catalog_dependency{source_id=\"$item_id\"}, target_id)",
         "hide": 2,
         "includeAll": true,
         "current": {
@@ -373,10 +373,10 @@
           "value": "$__all"
         },
         "multi": true,
-        "name": "dep_item_ids",
+        "name": "deps",
         "options": [],
         "query": {
-          "query": "label_values(catalog_dependency{source_id=\"$cur_item_id\"}, target_id)",
+          "query": "label_values(catalog_dependency{source_id=\"$item_id\"}, target_id)",
           "refId": "PrometheusVariableQuery"
         },
         "refresh": 1,


### PR DESCRIPTION
- Introduced `items` selector with modes: `all`, `[cur]rent`, `[dep]endencies`, `hide`.
- Introduced `hchecks` selector with modes: `all`, `[cur]rent`, `[dep]endencies`, `hide`.
- Shortened `graphs` filter label from “failing only” to “failing”.
- Reordered timeline targets so current item is rendered before dependencies.
- Split and clarified legend prefixes:
  - `[cur it]` for current item state.
  - `[dep it]` for dependency item state.
  - `[cur hc]` for current item checks.
  - `[dep hc]` for dependency checks.
- Restored and aligned variable names with actual query semantics.
- Updated item data link titles to include item name instead of generic label :contentReference[oaicite:0]{index=0}

## Result
- Timeline filters are more expressive and allow fine-grained control over what is displayed.
- Clear visual distinction between current item and dependencies, both for state and checks.
- More readable legends and cleaner variable naming.
- Improved usability of item links directly from the timeline.