### PR TITLE
Add standalone container build for catalog service

### DIFF
--- a/services-core/catalog/Dockerfile
+++ b/services-core/catalog/Dockerfile
@@ -1,0 +1,29 @@
+# -------- Build stage --------
+FROM golang:1.23-alpine AS build
+
+WORKDIR /app
+
+COPY go.mod ./
+COPY main.go ./
+
+RUN go mod download
+RUN CGO_ENABLED=0 GOOS=linux go build -mod=mod -trimpath -ldflags="-s -w" -o /out/catalog-service .
+
+# -------- Runtime stage --------
+FROM alpine:3.21
+
+WORKDIR /app
+
+RUN adduser -D -u 1001 appuser
+USER appuser
+
+COPY --from=build /out/catalog-service /usr/local/bin/catalog-service
+COPY catalog ./catalog
+COPY schemas ./schemas
+
+ENV CATALOG_DIR=./catalog/empty
+ENV PORT=8080
+
+EXPOSE 8080
+
+ENTRYPOINT ["catalog-service"]

--- a/services-core/catalog/go.mod
+++ b/services-core/catalog/go.mod
@@ -1,0 +1,5 @@
+module catalog
+
+go 1.23
+
+require gopkg.in/yaml.v3 v3.0.1


### PR DESCRIPTION
- Introduced a dedicated container image definition for the catalog service, enabling it to be built and run independently as part of the stack.
- Added Go module manifest setup to establish explicit dependency management and reproducible builds for the catalog service.
- Standardized the service packaging flow so catalog schemas and bundled demo data are included directly in the runtime image.
- Prepared the catalog service for cleaner deployment workflows across local demo, CI, and future environment overlays.