### PR TITLE
Transfer demo and empty catalogs under "catalog" directory

### DIFF
--- a/services-core/catalog/catalog/demo/catalog-actors-contacts.yaml
+++ b/services-core/catalog/catalog/demo/catalog-actors-contacts.yaml
@@ -1,0 +1,151 @@
+# yaml-language-server: $schema=../schemas/catalog-actors-contacts.schema.yaml
+actorContacts:
+  - actorId: ac_m7k2p9qd
+    contactId: ct_p2v6d4rw
+    isPrimary: true
+  - actorId: ac_m7k2p9qd
+    contactId: ct_h3m8q1tz
+  - actorId: ac_m7k2p9qd
+    contactId: ct_7n4k2p9a
+
+  - actorId: ac_r4t8w1nx
+    contactId: ct_t8r1w6qp
+    isPrimary: true
+  - actorId: ac_r4t8w1nx
+    contactId: ct_m4c7n2yf
+  - actorId: ac_r4t8w1nx
+    contactId: ct_f9q6m1xp
+
+  - actorId: ac_l6v3s9jb
+    contactId: ct_l6s4v9jr
+    isPrimary: true
+  - actorId: ac_l6v3s9jb
+    contactId: ct_k2p9m4sb
+  - actorId: ac_l6v3s9jb
+    contactId: ct_y5b1q7tc
+
+  - actorId: ac_j5d2m8pf
+    contactId: ct_j7d3m8pn
+    isPrimary: true
+  - actorId: ac_j5d2m8pf
+    contactId: ct_d5f2h9km
+
+  - actorId: ac_b9x4k7rc
+    contactId: ct_b9x5k3jd
+    isPrimary: true
+  - actorId: ac_b9x4k7rc
+    contactId: ct_v6j1t7rc
+
+  - actorId: ac_q7n3v8mt
+    contactId: ct_q7l3v8nx
+    isPrimary: true
+  - actorId: ac_q7n3v8mt
+    contactId: ct_g2n8x3mf
+
+  - actorId: ac_h2c9r6vy
+    contactId: ct_n8w3d5zg
+    isPrimary: true
+  - actorId: ac_h2c9r6vy
+    contactId: ct_c4r9k2vw
+
+  - actorId: ac_t4p6h1ks
+    contactId: ct_z1h7p5kd
+    isPrimary: true
+
+  - actorId: ac_f8m2c7tr
+    contactId: ct_w3c8t2bn
+    isPrimary: true
+  - actorId: ac_f8m2c7tr
+    contactId: ct_u2h9c5wf
+
+  - actorId: ac_n3q8w6zd
+    contactId: ct_x4d7p1ne
+    isPrimary: true
+  - actorId: ac_n3q8w6zd
+    contactId: ct_s9m2v4qa
+  - actorId: ac_n3q8w6zd
+    contactId: ct_v1f8d4hr
+
+  - actorId: ac_u7m1k5vr
+    contactId: ct_e8k3t6ru
+    isPrimary: true
+  - actorId: ac_u7m1k5vr
+    contactId: ct_u2h9c5wf
+
+  - actorId: ac_p4t9x2cb
+    contactId: ct_p6z1r3ty
+    isPrimary: true
+  - actorId: ac_p4t9x2cb
+    contactId: ct_a7q4n8lm
+
+  - actorId: ac_d8f3v7hl
+    contactId: ct_m9b5k2cv
+    isPrimary: true
+  - actorId: ac_d8f3v7hl
+    contactId: ct_v1f8d4hr
+
+  - actorId: ac_s6j2n9qw
+    contactId: ct_k4p9s7mg
+    isPrimary: true
+  - actorId: ac_s6j2n9qw
+    contactId: ct_b6h1x5qn
+
+  - actorId: ac_y5r4c8mt
+    contactId: ct_t3n7y6kp
+    isPrimary: true
+  - actorId: ac_y5r4c8mt
+    contactId: ct_r8w2c9jd
+
+  - actorId: ac_c7v1b4nk
+    contactId: ct_s9m2v4qa
+    isPrimary: true
+  - actorId: ac_c7v1b4nk
+    contactId: ct_d5f2h9km
+
+  - actorId: ac_h9p3m6tx
+    contactId: ct_a7q4n8lm
+    isPrimary: true
+  - actorId: ac_h9p3m6tx
+    contactId: ct_p6z1r3ty
+
+  - actorId: ac_l2d8q5rf
+    contactId: ct_k4p9s7mg
+    isPrimary: true
+  - actorId: ac_l2d8q5rf
+    contactId: ct_b6h1x5qn
+
+  - actorId: ac_w2h7m4pd
+    contactId: ct_n4t7c1km
+    isPrimary: true
+  - actorId: ac_w2h7m4pd
+    contactId: ct_h6p2r8vd
+
+  - actorId: ac_g6k1t9rv
+    contactId: ct_q3m6b9xr
+    isPrimary: true
+  - actorId: ac_g6k1t9rv
+    contactId: ct_h3m8q1tz
+
+  - actorId: ac_n5b3q8lz
+    contactId: ct_w8k5d2pf
+    isPrimary: true
+  - actorId: ac_n5b3q8lz
+    contactId: ct_f9q6m1xp
+
+  - actorId: ac_r1m8c6px
+    contactId: ct_d1r9v4zb
+    isPrimary: true
+  - actorId: ac_r1m8c6px
+    contactId: ct_y5b1q7tc
+
+  - actorId: ac_t9v2k4hs
+    contactId: ct_l3c7h2my
+    isPrimary: true
+  - actorId: ac_t9v2k4hs
+    contactId: ct_b6h1x5qn
+
+  - actorId: ac_f3p7d1qw
+    contactId: ct_s8q4n6tp
+    isPrimary: true
+  - actorId: ac_f3p7d1qw
+    contactId: ct_r8w2c9jd

--- a/services-core/catalog/catalog/demo/catalog-actors.yaml
+++ b/services-core/catalog/catalog/demo/catalog-actors.yaml
@@ -1,0 +1,146 @@
+# yaml-language-server: $schema=../schemas/catalog-actors.schema.yaml
+actors:
+  - id: ac_m7k2p9qd
+    title: Commerce Ownership Team
+    type: owner
+    description: |
+      Owns end-to-end reliability and delivery for core commerce capabilities.
+      Coordinates roadmap priorities across order intake, validation, billing, and fulfillment integration points.
+  - id: ac_r4t8w1nx
+    title: Operations Ownership Team
+    type: owner
+    description: |
+      Owns operational continuity for routing, inventory, dispatch, and returns flows.
+      Focuses on incident prevention, recovery speed, and predictable service behavior during traffic peaks.
+  - id: ac_l6v3s9jb
+    title: Experience Ownership Team
+    type: owner
+    description: |
+      Focuses on ensuring and measuring customer experience in Finance and engagement operations.
+      Mainly located in Belgrade (Serbia), with several members in the USA and Australia.
+  - id: ac_j5d2m8pf
+    title: Commerce Operations Lead
+    type: user
+    description: |
+      Leads day-to-day commerce operations and cross-team escalations for order-domain services.
+      Acts as the first operational decision-maker during active incidents and release rollouts.
+  - id: ac_b9x4k7rc
+    title: Operations Shift Lead
+    type: user
+    description: |
+      Coordinates shift-level response across operations systems and logistics-critical dependencies.
+      Maintains runbooks and orchestrates handovers between regional support rotations.
+  - id: ac_q7n3v8mt
+    title: Experience Product Lead
+    type: user
+    description: |
+      Drives product priorities for customer-facing experience components and campaign tooling.
+      Aligns analytics, experimentation, and delivery teams on customer-impacting changes.
+  - id: ac_h2c9r6vy
+    title: Customer Support Hotline
+    type: other
+    description: |
+      Shared hotline used for urgent customer-impacting issues that require immediate human response.
+      Used when ownership is unclear or when cross-domain communication must be started quickly.
+  - id: ac_t4p6h1ks
+    title: Security Response Desk
+    type: other
+    description: |
+      Security triage point for suspicious events, abuse patterns, and policy-related incidents.
+      Provides incident classification and recommended containment actions.
+  - id: ac_f8m2c7tr
+    title: Release Management Bridge
+    type: other
+    description: |
+      Coordinates high-risk deployments and rollback decisions across multiple technical domains.
+      Maintains release windows, change approvals, and communication during launch activities.
+  - id: ac_n3q8w6zd
+    title: Risk Ownership Team
+    type: owner
+    description: |
+      Owns fraud prevention, policy evaluation, and risk controls in the order intake flow.
+      Balances conversion impact with abuse containment and compliance requirements.
+  - id: ac_u7m1k5vr
+    title: Billing Ownership Team
+    type: owner
+    description: |
+      Owns billing orchestration, payment authorization adapters, and invoice delivery reliability.
+      Coordinates finance-impacting incident response and reconciliation quality.
+  - id: ac_p4t9x2cb
+    title: Routing Ownership Team
+    type: owner
+    description: |
+      Owns route planning, route cache consistency, and route cost model behavior.
+      Focuses on dispatch precision and degradation control during peak hours.
+  - id: ac_d8f3v7hl
+    title: Inventory Ownership Team
+    type: owner
+    description: |
+      Owns stock visibility, reservation integrity, and inventory reconciliation flows.
+      Drives consistency guarantees between physical and system inventory states.
+  - id: ac_s6j2n9qw
+    title: Messaging Ownership Team
+    type: owner
+    description: |
+      Owns message template rendering, channel delivery routing, and messaging SLA health.
+      Maintains reliability across email, push, and chat-based delivery channels.
+  - id: ac_y5r4c8mt
+    title: Campaign Ownership Team
+    type: owner
+    description: |
+      Owns campaign execution, segmentation runtime, and budget-guard enforcement services.
+      Optimizes release safety for marketing-critical launches and seasonal spikes.
+  - id: ac_c7v1b4nk
+    title: Risk Operations Lead
+    type: user
+    description: |
+      Coordinates real-time risk escalations and incident triage for fraud and policy incidents.
+      Leads communication between commerce operations, trust, and customer support teams.
+  - id: ac_h9p3m6tx
+    title: Routing Shift Lead
+    type: user
+    description: |
+      Handles shift-level routing incidents, model regressions, and emergency reroute procedures.
+      Maintains routing runbooks and validates fallback behavior during outages.
+  - id: ac_l2d8q5rf
+    title: Messaging Product Lead
+    type: user
+    description: |
+      Aligns messaging platform reliability work with customer communication priorities.
+      Owns messaging incident postmortems and cross-team action tracking.
+  - id: ac_w2h7m4pd
+    title: Order Workflow Ownership Team
+    type: owner
+    description: |
+      Owns order-domain workflow engines, intake adapters, and order-state projection reliability.
+      Coordinates multi-step order lifecycle incident response and backlog priorities.
+  - id: ac_g6k1t9rv
+    title: Commerce Platform Ownership Team
+    type: owner
+    description: |
+      Owns shared commerce platform capabilities and cross-cutting contract stability.
+      Focuses on platform-level reliability for upstream and downstream order integrations.
+  - id: ac_n5b3q8lz
+    title: Dispatch Ownership Team
+    type: owner
+    description: |
+      Owns dispatch orchestration, fulfillment control paths, and last-mile execution systems.
+      Leads operational response for dispatch-critical incidents and delivery degradations.
+  - id: ac_r1m8c6px
+    title: Experience Foundations Ownership Team
+    type: owner
+    description: |
+      Owns foundational experience services used by multiple customer-facing products.
+      Maintains baseline reliability, performance envelopes, and shared domain contracts.
+  - id: ac_t9v2k4hs
+    title: Profile Ownership Team
+    type: owner
+    description: |
+      Owns profile core data services, identity resolution, and merge orchestration reliability.
+      Drives profile data quality standards and incident prevention controls.
+  - id: ac_f3p7d1qw
+    title: Journey Ownership Team
+    type: owner
+    description: |
+      Owns journey and intent processing systems that orchestrate customer progression flows.
+      Maintains reliability of decision paths and experimentation guardrails.

--- a/services-core/catalog/catalog/demo/catalog-contacts.yaml
+++ b/services-core/catalog/catalog/demo/catalog-contacts.yaml
@@ -1,0 +1,158 @@
+﻿# yaml-language-server: $schema=../schemas/catalog-contacts.schema.yaml
+contacts:
+  - id: ct_7n4k2p9a
+    title: customer-department@demo.email
+    type: email
+    href: /contacts/ct_7n4k2p9a
+  - id: ct_h3m8q1tz
+    title: "#commerce-support"
+    type: slack
+    href: /contacts/ct_h3m8q1tz
+  - id: ct_p2v6d4rw
+    title: Commerce Primary On-Call
+    type: pagerduty
+    href: /contacts/ct_p2v6d4rw
+  - id: ct_b9x5k3jd
+    title: sre-ops@demo.email
+    type: email
+    href: /contacts/ct_b9x5k3jd
+  - id: ct_m4c7n2yf
+    title: Operations Command Center
+    type: teams
+    href: /contacts/ct_m4c7n2yf
+  - id: ct_t8r1w6qp
+    title: Platform Operations On-Call
+    type: opsgenie
+    href: /contacts/ct_t8r1w6qp
+  - id: ct_d5f2h9km
+    title: john.doe@demo.email
+    type: email
+    href: /contacts/ct_d5f2h9km
+  - id: ct_q7l3v8nx
+    title: "@customer_success_demo"
+    type: telegram
+    href: /contacts/ct_q7l3v8nx
+  - id: ct_k2p9m4sb
+    title: Customer Hub
+    type: discord
+    href: /contacts/ct_k2p9m4sb
+  - id: ct_v6j1t7rc
+    title: "#order-fulfillment"
+    type: slack
+    href: /contacts/ct_v6j1t7rc
+  - id: ct_n8w3d5zg
+    title: +1 202-555-0147
+    type: phone
+    href: /contacts/ct_n8w3d5zg
+  - id: ct_r4y2k7lh
+    title: +1 202-555-0191
+    type: sms
+    href: /contacts/ct_r4y2k7lh
+  - id: ct_f9q6m1xp
+    title: Logistics Control Room
+    type: teams
+    href: /contacts/ct_f9q6m1xp
+  - id: ct_w3c8t2bn
+    title: logistics-war-room
+    type: mattermost
+    href: /contacts/ct_w3c8t2bn
+  - id: ct_z1h7p5kd
+    title: Logistics Escalation
+    type: pagerduty
+    href: /contacts/ct_z1h7p5kd
+  - id: ct_l6s4v9jr
+    title: profile-team@demo.email
+    type: email
+    href: /contacts/ct_l6s4v9jr
+  - id: ct_g2n8x3mf
+    title: "#messaging-alerts"
+    type: slack
+    href: /contacts/ct_g2n8x3mf
+  - id: ct_y5b1q7tc
+    title: Campaign Operations
+    type: teams
+    href: /contacts/ct_y5b1q7tc
+  - id: ct_c4r9k2vw
+    title: +1 202-555-0112
+    type: phone
+    href: /contacts/ct_c4r9k2vw
+  - id: ct_j7d3m8pn
+    title: platform-oncall@demo.email
+    type: email
+    href: /contacts/ct_j7d3m8pn
+  - id: ct_s9m2v4qa
+    title: "#risk-watchtower"
+    type: slack
+    href: /contacts/ct_s9m2v4qa
+  - id: ct_x4d7p1ne
+    title: Risk Incident Commander
+    type: pagerduty
+    href: /contacts/ct_x4d7p1ne
+  - id: ct_e8k3t6ru
+    title: finance-ops@demo.email
+    type: email
+    href: /contacts/ct_e8k3t6ru
+  - id: ct_u2h9c5wf
+    title: Billing War Room
+    type: teams
+    href: /contacts/ct_u2h9c5wf
+  - id: ct_a7q4n8lm
+    title: "#routing-mesh"
+    type: slack
+    href: /contacts/ct_a7q4n8lm
+  - id: ct_p6z1r3ty
+    title: Route Reliability On-Call
+    type: opsgenie
+    href: /contacts/ct_p6z1r3ty
+  - id: ct_m9b5k2cv
+    title: inventory-control@demo.email
+    type: email
+    href: /contacts/ct_m9b5k2cv
+  - id: ct_v1f8d4hr
+    title: +1 202-555-0174
+    type: phone
+    href: /contacts/ct_v1f8d4hr
+  - id: ct_t3n7y6kp
+    title: "#campaign-delivery"
+    type: slack
+    href: /contacts/ct_t3n7y6kp
+  - id: ct_r8w2c9jd
+    title: Journey Experiments Desk
+    type: teams
+    href: /contacts/ct_r8w2c9jd
+  - id: ct_b6h1x5qn
+    title: profile-data-guard@demo.email
+    type: email
+    href: /contacts/ct_b6h1x5qn
+  - id: ct_k4p9s7mg
+    title: Messaging Response On-Call
+    type: pagerduty
+    href: /contacts/ct_k4p9s7mg
+  - id: ct_h6p2r8vd
+    title: "#order-workflow-ops"
+    type: slack
+    href: /contacts/ct_h6p2r8vd
+  - id: ct_n4t7c1km
+    title: Order Workflow On-Call
+    type: pagerduty
+    href: /contacts/ct_n4t7c1km
+  - id: ct_q3m6b9xr
+    title: commerce-platform@demo.email
+    type: email
+    href: /contacts/ct_q3m6b9xr
+  - id: ct_w8k5d2pf
+    title: Dispatch Command Bridge
+    type: teams
+    href: /contacts/ct_w8k5d2pf
+  - id: ct_d1r9v4zb
+    title: "#experience-foundations"
+    type: slack
+    href: /contacts/ct_d1r9v4zb
+  - id: ct_l3c7h2my
+    title: profile-core-oncall@demo.email
+    type: email
+    href: /contacts/ct_l3c7h2my
+  - id: ct_s8q4n6tp
+    title: Journey Rules On-Call
+    type: opsgenie
+    href: /contacts/ct_s8q4n6tp

--- a/services-core/catalog/catalog/demo/catalog-dependencies.yaml
+++ b/services-core/catalog/catalog/demo/catalog-dependencies.yaml
@@ -1,0 +1,160 @@
+# yaml-language-server: $schema=../schemas/catalog-dependencies.schema.yaml
+dependencies:
+  - sourceId: it_e7f7ec2d
+    targetId: it_6307a2a8
+  - sourceId: it_e7f7ec2d
+    targetId: it_5b917d99
+  - sourceId: it_6307a2a8
+    targetId: it_8be9ba4f
+  - sourceId: it_5b917d99
+    targetId: it_144bbdb0
+  - sourceId: it_8be9ba4f
+    targetId: it_144bbdb0
+  - sourceId: it_144bbdb0
+    targetId: it_008a7af7
+  - sourceId: it_144bbdb0
+    targetId: it_1668c093
+  - sourceId: it_144bbdb0
+    targetId: it_6c7923ab
+  - sourceId: it_008a7af7
+    targetId: it_5a9ca947
+  - sourceId: it_1668c093
+    targetId: it_31cdf080
+  - sourceId: it_6c7923ab
+    targetId: it_b0833df4
+  - sourceId: it_5a9ca947
+    targetId: it_43ab1049
+  - sourceId: it_31cdf080
+    targetId: it_43ab1049
+  - sourceId: it_b0833df4
+    targetId: it_43ab1049
+  - sourceId: it_43ab1049
+    targetId: it_ca854f7f
+  - sourceId: it_51dae4dd
+    targetId: it_571c410e
+  - sourceId: it_51dae4dd
+    targetId: it_c51a1ccc
+  - sourceId: it_571c410e
+    targetId: it_0387f962
+  - sourceId: it_0387f962
+    targetId: it_978f32ea
+  - sourceId: it_978f32ea
+    targetId: it_ef57ee00
+  - sourceId: it_978f32ea
+    targetId: it_906f7e0d
+  - sourceId: it_ef57ee00
+    targetId: it_48bb5977
+  - sourceId: it_906f7e0d
+    targetId: it_34b1b4e7
+  - sourceId: it_48bb5977
+    targetId: it_05c82f52
+  - sourceId: it_34b1b4e7
+    targetId: it_05c82f52
+  - sourceId: it_05c82f52
+    targetId: it_0d5a82d5
+  - sourceId: it_05c82f52
+    targetId: it_4395c1de
+  - sourceId: it_c51a1ccc
+    targetId: it_48bb5977
+  - sourceId: it_9d9e5627
+    targetId: it_5c743f44
+  - sourceId: it_9d9e5627
+    targetId: it_741e7f6b
+  - sourceId: it_5c743f44
+    targetId: it_6e67d308
+  - sourceId: it_741e7f6b
+    targetId: it_6e67d308
+  - sourceId: it_6e67d308
+    targetId: it_d01a646d
+  - sourceId: it_d01a646d
+    targetId: it_71574a7b
+  - sourceId: it_71574a7b
+    targetId: it_bee18e53
+  - sourceId: it_bee18e53
+    targetId: it_a0a28b85
+  - sourceId: it_bee18e53
+    targetId: it_4869434a
+  - sourceId: it_bee18e53
+    targetId: it_e8e0d47a
+  - sourceId: it_a0a28b85
+    targetId: it_5622ffff
+  - sourceId: it_a0a28b85
+    targetId: it_5d0def3d
+  - sourceId: it_5622ffff
+    targetId: it_92628e0a
+  - sourceId: it_5d0def3d
+    targetId: it_92628e0a
+  - sourceId: it_4869434a
+    targetId: it_ccf17b90
+  - sourceId: it_4869434a
+    targetId: it_e6af80a7
+  - sourceId: it_ccf17b90
+    targetId: it_51735b03
+  - sourceId: it_e6af80a7
+    targetId: it_51735b03
+  - sourceId: it_e8e0d47a
+    targetId: it_352b4411
+  - sourceId: it_e8e0d47a
+    targetId: it_ae13d093
+  - sourceId: it_352b4411
+    targetId: it_8f468246
+  - sourceId: it_ae13d093
+    targetId: it_8f468246
+  - sourceId: it_8be9ba4f
+    targetId: it_b61910c1
+  - sourceId: it_144bbdb0
+    targetId: it_1151701c
+  - sourceId: it_008a7af7
+    targetId: it_2484e0db
+  - sourceId: it_008a7af7
+    targetId: it_fbb05062
+  - sourceId: it_1668c093
+    targetId: it_96952012
+  - sourceId: it_1668c093
+    targetId: it_65839693
+  - sourceId: it_6c7923ab
+    targetId: it_3ca8ec85
+  - sourceId: it_6c7923ab
+    targetId: it_4c046b1d
+  - sourceId: it_43ab1049
+    targetId: it_9e60bdd7
+  - sourceId: it_43ab1049
+    targetId: it_3160377e
+  - sourceId: it_0387f962
+    targetId: it_bd3e8b82
+  - sourceId: it_978f32ea
+    targetId: it_9ead5a94
+  - sourceId: it_ef57ee00
+    targetId: it_9de17f36
+  - sourceId: it_ef57ee00
+    targetId: it_ed0d04bb
+  - sourceId: it_906f7e0d
+    targetId: it_20cb3376
+  - sourceId: it_906f7e0d
+    targetId: it_7199280d
+  - sourceId: it_05c82f52
+    targetId: it_2df0c55c
+  - sourceId: it_05c82f52
+    targetId: it_116e2e82
+  - sourceId: it_c51a1ccc
+    targetId: it_a6854c60
+  - sourceId: it_741e7f6b
+    targetId: it_9c69814b
+  - sourceId: it_6e67d308
+    targetId: it_0c7f7cbf
+  - sourceId: it_d01a646d
+    targetId: it_40d8cd7c
+  - sourceId: it_d01a646d
+    targetId: it_12a5d380
+  - sourceId: it_bee18e53
+    targetId: it_5e0132b8
+  - sourceId: it_a0a28b85
+    targetId: it_7e7405d3
+  - sourceId: it_4869434a
+    targetId: it_6cab1e6f
+  - sourceId: it_4869434a
+    targetId: it_984c1c25
+  - sourceId: it_e8e0d47a
+    targetId: it_86ccee33
+  - sourceId: it_e8e0d47a
+    targetId: it_29082314

--- a/services-core/catalog/catalog/demo/catalog-item-actors.yaml
+++ b/services-core/catalog/catalog/demo/catalog-item-actors.yaml
@@ -1,0 +1,321 @@
+# yaml-language-server: $schema=../schemas/catalog-item-actors.schema.yaml
+itemActors:
+  - itemId: it_e7f7ec2d
+    actorId: ac_g6k1t9rv
+  - itemId: it_e7f7ec2d
+    actorId: ac_j5d2m8pf
+  - itemId: it_e7f7ec2d
+    actorId: ac_h2c9r6vy
+
+  - itemId: it_51dae4dd
+    actorId: ac_n5b3q8lz
+  - itemId: it_51dae4dd
+    actorId: ac_b9x4k7rc
+  - itemId: it_51dae4dd
+    actorId: ac_f8m2c7tr
+
+  - itemId: it_9d9e5627
+    actorId: ac_l6v3s9jb
+  - itemId: it_9d9e5627
+    actorId: ac_q7n3v8mt
+  - itemId: it_9d9e5627
+    actorId: ac_h2c9r6vy
+
+  - itemId: it_6307a2a8
+    actorId: ac_g6k1t9rv
+  - itemId: it_6307a2a8
+    actorId: ac_j5d2m8pf
+  - itemId: it_5b917d99
+    actorId: ac_g6k1t9rv
+  - itemId: it_5b917d99
+    actorId: ac_j5d2m8pf
+  - itemId: it_8be9ba4f
+    actorId: ac_g6k1t9rv
+  - itemId: it_8be9ba4f
+    actorId: ac_j5d2m8pf
+  - itemId: it_144bbdb0
+    actorId: ac_w2h7m4pd
+  - itemId: it_144bbdb0
+    actorId: ac_j5d2m8pf
+  - itemId: it_008a7af7
+    actorId: ac_w2h7m4pd
+  - itemId: it_008a7af7
+    actorId: ac_j5d2m8pf
+  - itemId: it_1668c093
+    actorId: ac_n3q8w6zd
+  - itemId: it_1668c093
+    actorId: ac_c7v1b4nk
+  - itemId: it_1668c093
+    actorId: ac_t4p6h1ks
+  - itemId: it_6c7923ab
+    actorId: ac_u7m1k5vr
+  - itemId: it_6c7923ab
+    actorId: ac_j5d2m8pf
+  - itemId: it_43ab1049
+    actorId: ac_w2h7m4pd
+  - itemId: it_43ab1049
+    actorId: ac_j5d2m8pf
+
+  - itemId: it_571c410e
+    actorId: ac_n5b3q8lz
+  - itemId: it_571c410e
+    actorId: ac_b9x4k7rc
+  - itemId: it_c51a1ccc
+    actorId: ac_n5b3q8lz
+  - itemId: it_c51a1ccc
+    actorId: ac_b9x4k7rc
+  - itemId: it_0387f962
+    actorId: ac_n5b3q8lz
+  - itemId: it_0387f962
+    actorId: ac_b9x4k7rc
+  - itemId: it_978f32ea
+    actorId: ac_n5b3q8lz
+  - itemId: it_978f32ea
+    actorId: ac_b9x4k7rc
+  - itemId: it_ef57ee00
+    actorId: ac_p4t9x2cb
+  - itemId: it_ef57ee00
+    actorId: ac_h9p3m6tx
+  - itemId: it_906f7e0d
+    actorId: ac_d8f3v7hl
+  - itemId: it_906f7e0d
+    actorId: ac_b9x4k7rc
+  - itemId: it_05c82f52
+    actorId: ac_d8f3v7hl
+  - itemId: it_05c82f52
+    actorId: ac_b9x4k7rc
+
+  - itemId: it_5c743f44
+    actorId: ac_r1m8c6px
+  - itemId: it_5c743f44
+    actorId: ac_q7n3v8mt
+  - itemId: it_741e7f6b
+    actorId: ac_r1m8c6px
+  - itemId: it_741e7f6b
+    actorId: ac_q7n3v8mt
+  - itemId: it_6e67d308
+    actorId: ac_y5r4c8mt
+  - itemId: it_6e67d308
+    actorId: ac_q7n3v8mt
+  - itemId: it_d01a646d
+    actorId: ac_f3p7d1qw
+  - itemId: it_d01a646d
+    actorId: ac_q7n3v8mt
+  - itemId: it_bee18e53
+    actorId: ac_r1m8c6px
+  - itemId: it_bee18e53
+    actorId: ac_q7n3v8mt
+  - itemId: it_a0a28b85
+    actorId: ac_t9v2k4hs
+  - itemId: it_a0a28b85
+    actorId: ac_q7n3v8mt
+  - itemId: it_4869434a
+    actorId: ac_s6j2n9qw
+  - itemId: it_4869434a
+    actorId: ac_l2d8q5rf
+  - itemId: it_e8e0d47a
+    actorId: ac_y5r4c8mt
+  - itemId: it_e8e0d47a
+    actorId: ac_q7n3v8mt
+  - itemId: it_5622ffff
+    actorId: ac_t9v2k4hs
+  - itemId: it_5622ffff
+    actorId: ac_q7n3v8mt
+  - itemId: it_5d0def3d
+    actorId: ac_t9v2k4hs
+  - itemId: it_5d0def3d
+    actorId: ac_q7n3v8mt
+  - itemId: it_ccf17b90
+    actorId: ac_s6j2n9qw
+  - itemId: it_ccf17b90
+    actorId: ac_q7n3v8mt
+  - itemId: it_e6af80a7
+    actorId: ac_s6j2n9qw
+  - itemId: it_e6af80a7
+    actorId: ac_q7n3v8mt
+  - itemId: it_352b4411
+    actorId: ac_y5r4c8mt
+  - itemId: it_352b4411
+    actorId: ac_q7n3v8mt
+  - itemId: it_ae13d093
+    actorId: ac_y5r4c8mt
+  - itemId: it_ae13d093
+    actorId: ac_q7n3v8mt
+
+  - itemId: it_5a9ca947
+    actorId: ac_w2h7m4pd
+  - itemId: it_5a9ca947
+    actorId: ac_j5d2m8pf
+  - itemId: it_31cdf080
+    actorId: ac_n3q8w6zd
+  - itemId: it_31cdf080
+    actorId: ac_c7v1b4nk
+  - itemId: it_31cdf080
+    actorId: ac_t4p6h1ks
+  - itemId: it_b0833df4
+    actorId: ac_u7m1k5vr
+  - itemId: it_b0833df4
+    actorId: ac_j5d2m8pf
+  - itemId: it_ca854f7f
+    actorId: ac_n5b3q8lz
+  - itemId: it_ca854f7f
+    actorId: ac_j5d2m8pf
+
+  - itemId: it_48bb5977
+    actorId: ac_p4t9x2cb
+  - itemId: it_48bb5977
+    actorId: ac_h9p3m6tx
+  - itemId: it_34b1b4e7
+    actorId: ac_d8f3v7hl
+  - itemId: it_34b1b4e7
+    actorId: ac_b9x4k7rc
+  - itemId: it_0d5a82d5
+    actorId: ac_n5b3q8lz
+  - itemId: it_0d5a82d5
+    actorId: ac_b9x4k7rc
+  - itemId: it_4395c1de
+    actorId: ac_n5b3q8lz
+  - itemId: it_4395c1de
+    actorId: ac_b9x4k7rc
+
+  - itemId: it_71574a7b
+    actorId: ac_y5r4c8mt
+  - itemId: it_71574a7b
+    actorId: ac_q7n3v8mt
+  - itemId: it_92628e0a
+    actorId: ac_t9v2k4hs
+  - itemId: it_92628e0a
+    actorId: ac_q7n3v8mt
+  - itemId: it_51735b03
+    actorId: ac_s6j2n9qw
+  - itemId: it_51735b03
+    actorId: ac_l2d8q5rf
+  - itemId: it_8f468246
+    actorId: ac_y5r4c8mt
+  - itemId: it_8f468246
+    actorId: ac_q7n3v8mt
+
+  - itemId: it_b61910c1
+    actorId: ac_g6k1t9rv
+  - itemId: it_b61910c1
+    actorId: ac_j5d2m8pf
+  - itemId: it_1151701c
+    actorId: ac_w2h7m4pd
+  - itemId: it_1151701c
+    actorId: ac_j5d2m8pf
+  - itemId: it_2484e0db
+    actorId: ac_w2h7m4pd
+  - itemId: it_2484e0db
+    actorId: ac_j5d2m8pf
+  - itemId: it_fbb05062
+    actorId: ac_w2h7m4pd
+  - itemId: it_fbb05062
+    actorId: ac_j5d2m8pf
+  - itemId: it_96952012
+    actorId: ac_n3q8w6zd
+  - itemId: it_96952012
+    actorId: ac_c7v1b4nk
+  - itemId: it_96952012
+    actorId: ac_t4p6h1ks
+  - itemId: it_65839693
+    actorId: ac_n3q8w6zd
+  - itemId: it_65839693
+    actorId: ac_c7v1b4nk
+  - itemId: it_3ca8ec85
+    actorId: ac_u7m1k5vr
+  - itemId: it_3ca8ec85
+    actorId: ac_j5d2m8pf
+  - itemId: it_4c046b1d
+    actorId: ac_u7m1k5vr
+  - itemId: it_4c046b1d
+    actorId: ac_j5d2m8pf
+  - itemId: it_9e60bdd7
+    actorId: ac_w2h7m4pd
+  - itemId: it_9e60bdd7
+    actorId: ac_j5d2m8pf
+  - itemId: it_3160377e
+    actorId: ac_w2h7m4pd
+  - itemId: it_3160377e
+    actorId: ac_j5d2m8pf
+
+  - itemId: it_bd3e8b82
+    actorId: ac_n5b3q8lz
+  - itemId: it_bd3e8b82
+    actorId: ac_b9x4k7rc
+  - itemId: it_9ead5a94
+    actorId: ac_n5b3q8lz
+  - itemId: it_9ead5a94
+    actorId: ac_b9x4k7rc
+  - itemId: it_9de17f36
+    actorId: ac_p4t9x2cb
+  - itemId: it_9de17f36
+    actorId: ac_h9p3m6tx
+  - itemId: it_ed0d04bb
+    actorId: ac_p4t9x2cb
+  - itemId: it_ed0d04bb
+    actorId: ac_h9p3m6tx
+  - itemId: it_20cb3376
+    actorId: ac_d8f3v7hl
+  - itemId: it_20cb3376
+    actorId: ac_b9x4k7rc
+  - itemId: it_7199280d
+    actorId: ac_d8f3v7hl
+  - itemId: it_7199280d
+    actorId: ac_b9x4k7rc
+  - itemId: it_2df0c55c
+    actorId: ac_d8f3v7hl
+  - itemId: it_2df0c55c
+    actorId: ac_b9x4k7rc
+  - itemId: it_116e2e82
+    actorId: ac_n5b3q8lz
+  - itemId: it_116e2e82
+    actorId: ac_b9x4k7rc
+  - itemId: it_a6854c60
+    actorId: ac_n5b3q8lz
+  - itemId: it_a6854c60
+    actorId: ac_b9x4k7rc
+  - itemId: it_a6854c60
+    actorId: ac_f8m2c7tr
+
+  - itemId: it_9c69814b
+    actorId: ac_f3p7d1qw
+  - itemId: it_9c69814b
+    actorId: ac_q7n3v8mt
+  - itemId: it_9c69814b
+    actorId: ac_h2c9r6vy
+  - itemId: it_0c7f7cbf
+    actorId: ac_f3p7d1qw
+  - itemId: it_0c7f7cbf
+    actorId: ac_q7n3v8mt
+  - itemId: it_40d8cd7c
+    actorId: ac_f3p7d1qw
+  - itemId: it_40d8cd7c
+    actorId: ac_q7n3v8mt
+  - itemId: it_12a5d380
+    actorId: ac_y5r4c8mt
+  - itemId: it_12a5d380
+    actorId: ac_q7n3v8mt
+  - itemId: it_5e0132b8
+    actorId: ac_f3p7d1qw
+  - itemId: it_5e0132b8
+    actorId: ac_q7n3v8mt
+  - itemId: it_7e7405d3
+    actorId: ac_t9v2k4hs
+  - itemId: it_7e7405d3
+    actorId: ac_q7n3v8mt
+  - itemId: it_6cab1e6f
+    actorId: ac_s6j2n9qw
+  - itemId: it_6cab1e6f
+    actorId: ac_l2d8q5rf
+  - itemId: it_984c1c25
+    actorId: ac_s6j2n9qw
+  - itemId: it_984c1c25
+    actorId: ac_l2d8q5rf
+  - itemId: it_86ccee33
+    actorId: ac_y5r4c8mt
+  - itemId: it_86ccee33
+    actorId: ac_q7n3v8mt
+  - itemId: it_29082314
+    actorId: ac_y5r4c8mt
+  - itemId: it_29082314
+    actorId: ac_q7n3v8mt

--- a/services-core/catalog/catalog/demo/catalog-item-contacts.yaml
+++ b/services-core/catalog/catalog/demo/catalog-item-contacts.yaml
@@ -1,0 +1,414 @@
+# yaml-language-server: $schema=../schemas/catalog-item-contacts.schema.yaml
+itemContacts:
+  - itemId: it_e7f7ec2d
+    contactId: ct_q7l3v8nx
+  - itemId: it_51dae4dd
+    contactId: ct_y5b1q7tc
+  - itemId: it_9d9e5627
+    contactId: ct_l6s4v9jr
+  - itemId: it_9d9e5627
+    contactId: ct_d5f2h9km
+  - itemId: it_6307a2a8
+    contactId: ct_w3c8t2bn
+  - itemId: it_6307a2a8
+    contactId: ct_z1h7p5kd
+  - itemId: it_6307a2a8
+    contactId: ct_v6j1t7rc
+  - itemId: it_5b917d99
+    contactId: ct_t8r1w6qp
+  - itemId: it_5b917d99
+    contactId: ct_y5b1q7tc
+  - itemId: it_5b917d99
+    contactId: ct_w3c8t2bn
+  - itemId: it_5b917d99
+    contactId: ct_p2v6d4rw
+  - itemId: it_8be9ba4f
+    contactId: ct_m4c7n2yf
+  - itemId: it_8be9ba4f
+    contactId: ct_7n4k2p9a
+  - itemId: it_144bbdb0
+    contactId: ct_p2v6d4rw
+  - itemId: it_144bbdb0
+    contactId: ct_m4c7n2yf
+  - itemId: it_144bbdb0
+    contactId: ct_k2p9m4sb
+  - itemId: it_144bbdb0
+    contactId: ct_7n4k2p9a
+  - itemId: it_008a7af7
+    contactId: ct_w3c8t2bn
+  - itemId: it_008a7af7
+    contactId: ct_y5b1q7tc
+  - itemId: it_1668c093
+    contactId: ct_q7l3v8nx
+  - itemId: it_1668c093
+    contactId: ct_b9x5k3jd
+  - itemId: it_1668c093
+    contactId: ct_r4y2k7lh
+  - itemId: it_1668c093
+    contactId: ct_y5b1q7tc
+  - itemId: it_6c7923ab
+    contactId: ct_j7d3m8pn
+  - itemId: it_6c7923ab
+    contactId: ct_d5f2h9km
+  - itemId: it_6c7923ab
+    contactId: ct_b9x5k3jd
+  - itemId: it_43ab1049
+    contactId: ct_f9q6m1xp
+  - itemId: it_43ab1049
+    contactId: ct_r4y2k7lh
+  - itemId: it_571c410e
+    contactId: ct_h3m8q1tz
+  - itemId: it_c51a1ccc
+    contactId: ct_t8r1w6qp
+  - itemId: it_c51a1ccc
+    contactId: ct_f9q6m1xp
+  - itemId: it_c51a1ccc
+    contactId: ct_c4r9k2vw
+  - itemId: it_c51a1ccc
+    contactId: ct_z1h7p5kd
+  - itemId: it_c51a1ccc
+    contactId: ct_r4y2k7lh
+  - itemId: it_0387f962
+    contactId: ct_y5b1q7tc
+  - itemId: it_978f32ea
+    contactId: ct_k2p9m4sb
+  - itemId: it_978f32ea
+    contactId: ct_v6j1t7rc
+  - itemId: it_978f32ea
+    contactId: ct_j7d3m8pn
+  - itemId: it_978f32ea
+    contactId: ct_g2n8x3mf
+  - itemId: it_978f32ea
+    contactId: ct_t8r1w6qp
+  - itemId: it_ef57ee00
+    contactId: ct_b9x5k3jd
+  - itemId: it_906f7e0d
+    contactId: ct_w3c8t2bn
+  - itemId: it_906f7e0d
+    contactId: ct_v6j1t7rc
+  - itemId: it_906f7e0d
+    contactId: ct_q7l3v8nx
+  - itemId: it_906f7e0d
+    contactId: ct_n8w3d5zg
+  - itemId: it_906f7e0d
+    contactId: ct_t8r1w6qp
+  - itemId: it_05c82f52
+    contactId: ct_p2v6d4rw
+  - itemId: it_05c82f52
+    contactId: ct_f9q6m1xp
+  - itemId: it_05c82f52
+    contactId: ct_r4y2k7lh
+  - itemId: it_05c82f52
+    contactId: ct_c4r9k2vw
+  - itemId: it_05c82f52
+    contactId: ct_q7l3v8nx
+  - itemId: it_5c743f44
+    contactId: ct_q7l3v8nx
+  - itemId: it_5c743f44
+    contactId: ct_j7d3m8pn
+  - itemId: it_5c743f44
+    contactId: ct_t8r1w6qp
+  - itemId: it_5c743f44
+    contactId: ct_n8w3d5zg
+  - itemId: it_5c743f44
+    contactId: ct_d5f2h9km
+  - itemId: it_741e7f6b
+    contactId: ct_7n4k2p9a
+  - itemId: it_741e7f6b
+    contactId: ct_f9q6m1xp
+  - itemId: it_741e7f6b
+    contactId: ct_l6s4v9jr
+  - itemId: it_741e7f6b
+    contactId: ct_w3c8t2bn
+  - itemId: it_741e7f6b
+    contactId: ct_j7d3m8pn
+  - itemId: it_6e67d308
+    contactId: ct_f9q6m1xp
+  - itemId: it_d01a646d
+    contactId: ct_r4y2k7lh
+  - itemId: it_bee18e53
+    contactId: ct_f9q6m1xp
+  - itemId: it_bee18e53
+    contactId: ct_h3m8q1tz
+  - itemId: it_bee18e53
+    contactId: ct_w3c8t2bn
+  - itemId: it_a0a28b85
+    contactId: ct_t8r1w6qp
+  - itemId: it_4869434a
+    contactId: ct_h3m8q1tz
+  - itemId: it_4869434a
+    contactId: ct_t8r1w6qp
+  - itemId: it_4869434a
+    contactId: ct_d5f2h9km
+  - itemId: it_4869434a
+    contactId: ct_r4y2k7lh
+  - itemId: it_e8e0d47a
+    contactId: ct_z1h7p5kd
+  - itemId: it_e8e0d47a
+    contactId: ct_n8w3d5zg
+  - itemId: it_e8e0d47a
+    contactId: ct_p2v6d4rw
+  - itemId: it_5622ffff
+    contactId: ct_b9x5k3jd
+  - itemId: it_5622ffff
+    contactId: ct_w3c8t2bn
+  - itemId: it_5622ffff
+    contactId: ct_l6s4v9jr
+  - itemId: it_5622ffff
+    contactId: ct_d5f2h9km
+  - itemId: it_5d0def3d
+    contactId: ct_y5b1q7tc
+  - itemId: it_5d0def3d
+    contactId: ct_p2v6d4rw
+  - itemId: it_5d0def3d
+    contactId: ct_t8r1w6qp
+  - itemId: it_5d0def3d
+    contactId: ct_w3c8t2bn
+  - itemId: it_5d0def3d
+    contactId: ct_k2p9m4sb
+  - itemId: it_ccf17b90
+    contactId: ct_h3m8q1tz
+  - itemId: it_e6af80a7
+    contactId: ct_k2p9m4sb
+  - itemId: it_e6af80a7
+    contactId: ct_w3c8t2bn
+  - itemId: it_e6af80a7
+    contactId: ct_7n4k2p9a
+  - itemId: it_e6af80a7
+    contactId: ct_m4c7n2yf
+  - itemId: it_e6af80a7
+    contactId: ct_d5f2h9km
+  - itemId: it_352b4411
+    contactId: ct_m4c7n2yf
+  - itemId: it_352b4411
+    contactId: ct_w3c8t2bn
+  - itemId: it_ae13d093
+    contactId: ct_m4c7n2yf
+  - itemId: it_ae13d093
+    contactId: ct_q7l3v8nx
+  - itemId: it_ae13d093
+    contactId: ct_c4r9k2vw
+  - itemId: it_ae13d093
+    contactId: ct_y5b1q7tc
+  - itemId: it_5a9ca947
+    contactId: ct_y5b1q7tc
+  - itemId: it_5a9ca947
+    contactId: ct_t8r1w6qp
+  - itemId: it_5a9ca947
+    contactId: ct_p2v6d4rw
+  - itemId: it_5a9ca947
+    contactId: ct_z1h7p5kd
+  - itemId: it_31cdf080
+    contactId: ct_z1h7p5kd
+  - itemId: it_31cdf080
+    contactId: ct_g2n8x3mf
+  - itemId: it_31cdf080
+    contactId: ct_r4y2k7lh
+  - itemId: it_31cdf080
+    contactId: ct_p2v6d4rw
+  - itemId: it_31cdf080
+    contactId: ct_d5f2h9km
+  - itemId: it_b0833df4
+    contactId: ct_y5b1q7tc
+  - itemId: it_b0833df4
+    contactId: ct_m4c7n2yf
+  - itemId: it_b0833df4
+    contactId: ct_w3c8t2bn
+  - itemId: it_b0833df4
+    contactId: ct_b9x5k3jd
+  - itemId: it_ca854f7f
+    contactId: ct_r4y2k7lh
+  - itemId: it_ca854f7f
+    contactId: ct_c4r9k2vw
+  - itemId: it_ca854f7f
+    contactId: ct_f9q6m1xp
+  - itemId: it_48bb5977
+    contactId: ct_k2p9m4sb
+  - itemId: it_48bb5977
+    contactId: ct_d5f2h9km
+  - itemId: it_48bb5977
+    contactId: ct_7n4k2p9a
+  - itemId: it_34b1b4e7
+    contactId: ct_f9q6m1xp
+  - itemId: it_34b1b4e7
+    contactId: ct_j7d3m8pn
+  - itemId: it_34b1b4e7
+    contactId: ct_b9x5k3jd
+  - itemId: it_0d5a82d5
+    contactId: ct_w3c8t2bn
+  - itemId: it_4395c1de
+    contactId: ct_y5b1q7tc
+  - itemId: it_4395c1de
+    contactId: ct_c4r9k2vw
+  - itemId: it_4395c1de
+    contactId: ct_m4c7n2yf
+  - itemId: it_71574a7b
+    contactId: ct_j7d3m8pn
+  - itemId: it_92628e0a
+    contactId: ct_k2p9m4sb
+  - itemId: it_51735b03
+    contactId: ct_7n4k2p9a
+  - itemId: it_51735b03
+    contactId: ct_t8r1w6qp
+  - itemId: it_51735b03
+    contactId: ct_d5f2h9km
+  - itemId: it_51735b03
+    contactId: ct_b9x5k3jd
+  - itemId: it_8f468246
+    contactId: ct_w3c8t2bn
+  - itemId: it_8f468246
+    contactId: ct_l6s4v9jr
+  - itemId: it_b61910c1
+    contactId: ct_r4y2k7lh
+  - itemId: it_1151701c
+    contactId: ct_q7l3v8nx
+  - itemId: it_1151701c
+    contactId: ct_l6s4v9jr
+  - itemId: it_2484e0db
+    contactId: ct_w3c8t2bn
+  - itemId: it_2484e0db
+    contactId: ct_r4y2k7lh
+  - itemId: it_fbb05062
+    contactId: ct_c4r9k2vw
+  - itemId: it_96952012
+    contactId: ct_z1h7p5kd
+  - itemId: it_96952012
+    contactId: ct_t8r1w6qp
+  - itemId: it_96952012
+    contactId: ct_m4c7n2yf
+  - itemId: it_96952012
+    contactId: ct_r4y2k7lh
+  - itemId: it_65839693
+    contactId: ct_7n4k2p9a
+  - itemId: it_65839693
+    contactId: ct_c4r9k2vw
+  - itemId: it_65839693
+    contactId: ct_k2p9m4sb
+  - itemId: it_3ca8ec85
+    contactId: ct_h3m8q1tz
+  - itemId: it_3ca8ec85
+    contactId: ct_j7d3m8pn
+  - itemId: it_3ca8ec85
+    contactId: ct_f9q6m1xp
+  - itemId: it_4c046b1d
+    contactId: ct_f9q6m1xp
+  - itemId: it_4c046b1d
+    contactId: ct_t8r1w6qp
+  - itemId: it_4c046b1d
+    contactId: ct_v6j1t7rc
+  - itemId: it_4c046b1d
+    contactId: ct_j7d3m8pn
+  - itemId: it_9e60bdd7
+    contactId: ct_l6s4v9jr
+  - itemId: it_9e60bdd7
+    contactId: ct_h3m8q1tz
+  - itemId: it_9e60bdd7
+    contactId: ct_m4c7n2yf
+  - itemId: it_9e60bdd7
+    contactId: ct_g2n8x3mf
+  - itemId: it_3160377e
+    contactId: ct_r4y2k7lh
+  - itemId: it_3160377e
+    contactId: ct_h3m8q1tz
+  - itemId: it_bd3e8b82
+    contactId: ct_y5b1q7tc
+  - itemId: it_bd3e8b82
+    contactId: ct_p2v6d4rw
+  - itemId: it_bd3e8b82
+    contactId: ct_w3c8t2bn
+  - itemId: it_bd3e8b82
+    contactId: ct_m4c7n2yf
+  - itemId: it_bd3e8b82
+    contactId: ct_g2n8x3mf
+  - itemId: it_9ead5a94
+    contactId: ct_h3m8q1tz
+  - itemId: it_9de17f36
+    contactId: ct_w3c8t2bn
+  - itemId: it_9de17f36
+    contactId: ct_j7d3m8pn
+  - itemId: it_9de17f36
+    contactId: ct_k2p9m4sb
+  - itemId: it_9de17f36
+    contactId: ct_v6j1t7rc
+  - itemId: it_9de17f36
+    contactId: ct_d5f2h9km
+  - itemId: it_ed0d04bb
+    contactId: ct_l6s4v9jr
+  - itemId: it_ed0d04bb
+    contactId: ct_b9x5k3jd
+  - itemId: it_ed0d04bb
+    contactId: ct_q7l3v8nx
+  - itemId: it_ed0d04bb
+    contactId: ct_f9q6m1xp
+  - itemId: it_20cb3376
+    contactId: ct_w3c8t2bn
+  - itemId: it_7199280d
+    contactId: ct_t8r1w6qp
+  - itemId: it_7199280d
+    contactId: ct_d5f2h9km
+  - itemId: it_7199280d
+    contactId: ct_p2v6d4rw
+  - itemId: it_7199280d
+    contactId: ct_h3m8q1tz
+  - itemId: it_7199280d
+    contactId: ct_g2n8x3mf
+  - itemId: it_2df0c55c
+    contactId: ct_n8w3d5zg
+  - itemId: it_2df0c55c
+    contactId: ct_t8r1w6qp
+  - itemId: it_116e2e82
+    contactId: ct_h3m8q1tz
+  - itemId: it_a6854c60
+    contactId: ct_y5b1q7tc
+  - itemId: it_a6854c60
+    contactId: ct_h3m8q1tz
+  - itemId: it_9c69814b
+    contactId: ct_w3c8t2bn
+  - itemId: it_9c69814b
+    contactId: ct_k2p9m4sb
+  - itemId: it_9c69814b
+    contactId: ct_z1h7p5kd
+  - itemId: it_9c69814b
+    contactId: ct_b9x5k3jd
+  - itemId: it_0c7f7cbf
+    contactId: ct_l6s4v9jr
+  - itemId: it_0c7f7cbf
+    contactId: ct_k2p9m4sb
+  - itemId: it_40d8cd7c
+    contactId: ct_z1h7p5kd
+  - itemId: it_40d8cd7c
+    contactId: ct_c4r9k2vw
+  - itemId: it_12a5d380
+    contactId: ct_y5b1q7tc
+  - itemId: it_5e0132b8
+    contactId: ct_v6j1t7rc
+  - itemId: it_5e0132b8
+    contactId: ct_7n4k2p9a
+  - itemId: it_7e7405d3
+    contactId: ct_7n4k2p9a
+  - itemId: it_7e7405d3
+    contactId: ct_k2p9m4sb
+  - itemId: it_6cab1e6f
+    contactId: ct_k2p9m4sb
+  - itemId: it_6cab1e6f
+    contactId: ct_p2v6d4rw
+  - itemId: it_6cab1e6f
+    contactId: ct_z1h7p5kd
+  - itemId: it_6cab1e6f
+    contactId: ct_h3m8q1tz
+  - itemId: it_6cab1e6f
+    contactId: ct_v6j1t7rc
+  - itemId: it_984c1c25
+    contactId: ct_z1h7p5kd
+  - itemId: it_984c1c25
+    contactId: ct_q7l3v8nx
+  - itemId: it_984c1c25
+    contactId: ct_n8w3d5zg
+  - itemId: it_984c1c25
+    contactId: ct_j7d3m8pn
+  - itemId: it_984c1c25
+    contactId: ct_m4c7n2yf
+  - itemId: it_86ccee33
+    contactId: ct_q7l3v8nx
+  - itemId: it_29082314
+    contactId: ct_c4r9k2vw

--- a/services-core/catalog/catalog/demo/catalog-items.yaml
+++ b/services-core/catalog/catalog/demo/catalog-items.yaml
@@ -1,0 +1,149 @@
+# yaml-language-server: $schema=../schemas/catalog-items.schema.yaml
+# Demo catalog with expanded service topology
+items:
+  - id: it_e7f7ec2d
+    title: Commerce Platform
+  - id: it_51dae4dd
+    title: Operations Suite
+  - id: it_9d9e5627
+    title: Customer Experience
+  - id: it_6307a2a8
+    title: Commerce Line Core
+  - id: it_5b917d99
+    title: Commerce Extensions
+  - id: it_8be9ba4f
+    title: Commerce Core
+  - id: it_144bbdb0
+    title: Order Domain
+  - id: it_008a7af7
+    title: Order Intake Hub
+  - id: it_1668c093
+    title: Order Guard Hub
+  - id: it_6c7923ab
+    title: Order Finance Hub
+  - id: it_43ab1049
+    title: Order Workflow
+  - id: it_571c410e
+    title: Operations Line
+  - id: it_c51a1ccc
+    title: Operations Accelerators
+  - id: it_0387f962
+    title: Fulfillment Hub
+  - id: it_978f32ea
+    title: Logistics Domain
+  - id: it_ef57ee00
+    title: Logistics Routing Cell
+  - id: it_906f7e0d
+    title: Logistics Inventory Cell
+  - id: it_05c82f52
+    title: Distribution Core
+  - id: it_5c743f44
+    title: Experience Line
+  - id: it_741e7f6b
+    title: Experience Foundation
+  - id: it_6e67d308
+    title: Engagement Suite
+  - id: it_d01a646d
+    title: Journey Domain
+  - id: it_bee18e53
+    title: Touchpoint Core
+  - id: it_a0a28b85
+    title: Touchpoint Profile Pillar
+  - id: it_4869434a
+    title: Touchpoint Messaging Pillar
+  - id: it_e8e0d47a
+    title: Touchpoint Campaign Pillar
+  - id: it_5622ffff
+    title: Profile Core Nodes
+  - id: it_5d0def3d
+    title: Profile Identity Nodes
+  - id: it_ccf17b90
+    title: Messaging Router Nodes
+  - id: it_e6af80a7
+    title: Messaging Template Nodes
+  - id: it_352b4411
+    title: Campaign Planner Nodes
+  - id: it_ae13d093
+    title: Campaign Optimizer Nodes
+  - id: it_5a9ca947
+    title: Order Capture Service
+  - id: it_31cdf080
+    title: Order Validation Service
+  - id: it_b0833df4
+    title: Order Billing Service
+  - id: it_ca854f7f
+    title: Order Dispatch Service
+  - id: it_48bb5977
+    title: Routing Engine Service
+  - id: it_34b1b4e7
+    title: Inventory Sync Service
+  - id: it_0d5a82d5
+    title: Last-Mile Dispatch Service
+  - id: it_4395c1de
+    title: Returns Processing Service
+  - id: it_71574a7b
+    title: Engagement Orchestrator Service
+  - id: it_92628e0a
+    title: Profile Store Service
+  - id: it_51735b03
+    title: Messaging Hub Service
+  - id: it_8f468246
+    title: Campaign Execution Service
+  - id: it_b61910c1
+    title: Commerce Core Pricing Sync Service
+  - id: it_1151701c
+    title: Order Domain Events Service
+  - id: it_2484e0db
+    title: Order Intake API Service
+  - id: it_fbb05062
+    title: Order Intake Buffer Service
+  - id: it_96952012
+    title: Fraud Screening Service
+  - id: it_65839693
+    title: Policy Evaluator Service
+  - id: it_3ca8ec85
+    title: Invoice Orchestrator Service
+  - id: it_4c046b1d
+    title: Payment Authorization Adapter Service
+  - id: it_9e60bdd7
+    title: Order State Projection Service
+  - id: it_3160377e
+    title: Order SLA Tracker Service
+  - id: it_bd3e8b82
+    title: Fulfillment Control Plane Service
+  - id: it_9ead5a94
+    title: Logistics Event Router Service
+  - id: it_9de17f36
+    title: Route Cache Writer Service
+  - id: it_ed0d04bb
+    title: Route Cost Model Service
+  - id: it_20cb3376
+    title: Inventory Reconciler Service
+  - id: it_7199280d
+    title: Stock Reservation Service
+  - id: it_2df0c55c
+    title: Depot Slotting Service
+  - id: it_116e2e82
+    title: Carrier Capacity Broker Service
+  - id: it_a6854c60
+    title: Dispatch Simulation Service
+  - id: it_9c69814b
+    title: Customer Consent Ledger Service
+  - id: it_0c7f7cbf
+    title: Audience Intent Processor Service
+  - id: it_40d8cd7c
+    title: Journey Rules Engine Service
+  - id: it_12a5d380
+    title: Journey Experimentation Service
+  - id: it_5e0132b8
+    title: Touchpoint Session State Service
+  - id: it_7e7405d3
+    title: Profile Merge Orchestrator Service
+  - id: it_6cab1e6f
+    title: Template Renderer Service
+  - id: it_984c1c25
+    title: Channel Delivery Router Service
+  - id: it_86ccee33
+    title: Campaign Segmentation Service
+  - id: it_29082314
+    title: Campaign Budget Guard Service

--- a/services-core/catalog/catalog/demo/signals-http-poll.yaml
+++ b/services-core/catalog/catalog/demo/signals-http-poll.yaml
@@ -1,0 +1,1027 @@
+# yaml-language-server: $schema=../schemas/signals-http-poll.schema.yaml
+# HTTP polling signals for demo services and product SLIs
+signals:
+  - id: sg_dc0a314b
+    title: Availability heartbeat responds
+    itemId: it_5a9ca947
+    url: http://dummy-java:8080/health/sg_dc0a314b
+  - id: sg_14bba996
+    title: Request latency is within SLO
+    itemId: it_5a9ca947
+    url: http://dummy-python:8080/health/sg_14bba996
+  - id: sg_38b30cac
+    title: Error rate is below threshold
+    itemId: it_5a9ca947
+    url: http://dummy-javascript:8080/health/sg_38b30cac
+  - id: sg_0e62eadc
+    title: Work backlog is within limits
+    itemId: it_5a9ca947
+    url: http://dummy-java:8080/health/sg_0e62eadc
+  - id: sg_ec3e610d
+    title: Availability heartbeat responds
+    itemId: it_31cdf080
+    url: http://dummy-python:8080/health/sg_ec3e610d
+  - id: sg_bc07d265
+    title: Request latency is within SLO
+    itemId: it_31cdf080
+    url: http://dummy-javascript:8080/health/sg_bc07d265
+  - id: sg_c1dbe217
+    title: Error rate is below threshold
+    itemId: it_31cdf080
+    url: http://dummy-java:8080/health/sg_c1dbe217
+  - id: sg_b1124af6
+    title: Work backlog is within limits
+    itemId: it_31cdf080
+    url: http://dummy-python:8080/health/sg_b1124af6
+  - id: sg_7bb1a473
+    title: Validation decisions complete within the policy window
+    itemId: it_31cdf080
+    url: http://dummy-javascript:8080/health/sg_7bb1a473
+  - id: sg_913afadb
+    title: Availability heartbeat responds
+    itemId: it_b0833df4
+    url: http://dummy-java:8080/health/sg_913afadb
+  - id: sg_b9cdfcc0
+    title: Request latency is within SLO
+    itemId: it_b0833df4
+    url: http://dummy-python:8080/health/sg_b9cdfcc0
+  - id: sg_3d57f647
+    title: Error rate is below threshold
+    itemId: it_b0833df4
+    url: http://dummy-javascript:8080/health/sg_3d57f647
+  - id: sg_b9d82030
+    title: Work backlog is within limits
+    itemId: it_b0833df4
+    url: http://dummy-java:8080/health/sg_b9d82030
+  - id: sg_c1ed2120
+    title: Billing totals remain internally balanced before issue
+    itemId: it_b0833df4
+    url: http://dummy-python:8080/health/sg_c1ed2120
+  - id: sg_2c289dd6
+    title: Availability heartbeat responds
+    itemId: it_ca854f7f
+    url: http://dummy-javascript:8080/health/sg_2c289dd6
+  - id: sg_f7e46eac
+    title: Availability heartbeat responds
+    itemId: it_48bb5977
+    url: http://dummy-java:8080/health/sg_f7e46eac
+  - id: sg_c257a362
+    title: Request latency is within SLO
+    itemId: it_48bb5977
+    url: http://dummy-python:8080/health/sg_c257a362
+  - id: sg_3488bf53
+    title: Error rate is below threshold
+    itemId: it_48bb5977
+    url: http://dummy-javascript:8080/health/sg_3488bf53
+  - id: sg_a7dae968
+    title: Work backlog is within limits
+    itemId: it_48bb5977
+    url: http://dummy-java:8080/health/sg_a7dae968
+  - id: sg_f615fcab
+    title: Availability heartbeat responds
+    itemId: it_34b1b4e7
+    url: http://dummy-python:8080/health/sg_f615fcab
+  - id: sg_e288db6b
+    title: Request latency is within SLO
+    itemId: it_34b1b4e7
+    url: http://dummy-javascript:8080/health/sg_e288db6b
+  - id: sg_a4aece2f
+    title: Error rate is below threshold
+    itemId: it_34b1b4e7
+    url: http://dummy-java:8080/health/sg_a4aece2f
+  - id: sg_01265390
+    title: Work backlog is within limits
+    itemId: it_34b1b4e7
+    url: http://dummy-python:8080/health/sg_01265390
+  - id: sg_43a902fa
+    title: Availability heartbeat responds
+    itemId: it_0d5a82d5
+    url: http://dummy-javascript:8080/health/sg_43a902fa
+  - id: sg_6f0184fe
+    title: Request latency is within SLO
+    itemId: it_0d5a82d5
+    url: http://dummy-java:8080/health/sg_6f0184fe
+  - id: sg_e3827320
+    title: Error rate is below threshold
+    itemId: it_0d5a82d5
+    url: http://dummy-python:8080/health/sg_e3827320
+  - id: sg_25cbf93f
+    title: Work backlog is within limits
+    itemId: it_0d5a82d5
+    url: http://dummy-javascript:8080/health/sg_25cbf93f
+  - id: sg_cae31577
+    title: Route commitments are produced within the dispatch window
+    itemId: it_0d5a82d5
+    url: http://dummy-java:8080/health/sg_cae31577
+  - id: sg_56836fa6
+    title: Availability heartbeat responds
+    itemId: it_4395c1de
+    url: http://dummy-python:8080/health/sg_56836fa6
+  - id: sg_db3b4bb3
+    title: Request latency is within SLO
+    itemId: it_4395c1de
+    url: http://dummy-javascript:8080/health/sg_db3b4bb3
+  - id: sg_9dd0d20c
+    title: Error rate is below threshold
+    itemId: it_4395c1de
+    url: http://dummy-java:8080/health/sg_9dd0d20c
+  - id: sg_adbe0fc5
+    title: Work backlog is within limits
+    itemId: it_4395c1de
+    url: http://dummy-python:8080/health/sg_adbe0fc5
+  - id: sg_fc7493a1
+    title: Return cases close within the expected handling window
+    itemId: it_4395c1de
+    url: http://dummy-javascript:8080/health/sg_fc7493a1
+  - id: sg_a75049ef
+    title: Availability heartbeat responds
+    itemId: it_71574a7b
+    url: http://dummy-java:8080/health/sg_a75049ef
+  - id: sg_c453b2b6
+    title: Availability heartbeat responds
+    itemId: it_92628e0a
+    url: http://dummy-python:8080/health/sg_c453b2b6
+  - id: sg_d417a6c6
+    title: Request latency is within SLO
+    itemId: it_92628e0a
+    url: http://dummy-javascript:8080/health/sg_d417a6c6
+  - id: sg_87a26b11
+    title: Error rate is below threshold
+    itemId: it_92628e0a
+    url: http://dummy-java:8080/health/sg_87a26b11
+  - id: sg_472963e7
+    title: Availability heartbeat responds
+    itemId: it_51735b03
+    url: http://dummy-python:8080/health/sg_472963e7
+  - id: sg_04a60045
+    title: Request latency is within SLO
+    itemId: it_51735b03
+    url: http://dummy-javascript:8080/health/sg_04a60045
+  - id: sg_3a29075b
+    title: Error rate is below threshold
+    itemId: it_51735b03
+    url: http://dummy-java:8080/health/sg_3a29075b
+  - id: sg_fabe1793
+    title: Work backlog is within limits
+    itemId: it_51735b03
+    url: http://dummy-python:8080/health/sg_fabe1793
+  - id: sg_f0b3ed3c
+    title: Message batches enter delivery within the target window
+    itemId: it_51735b03
+    url: http://dummy-javascript:8080/health/sg_f0b3ed3c
+  - id: sg_40314ec6
+    title: Availability heartbeat responds
+    itemId: it_8f468246
+    url: http://dummy-java:8080/health/sg_40314ec6
+  - id: sg_e81b7405
+    title: Request latency is within SLO
+    itemId: it_8f468246
+    url: http://dummy-python:8080/health/sg_e81b7405
+  - id: sg_71a723e2
+    title: Error rate is below threshold
+    itemId: it_8f468246
+    url: http://dummy-javascript:8080/health/sg_71a723e2
+  - id: sg_a7a20ae0
+    title: Work backlog is within limits
+    itemId: it_8f468246
+    url: http://dummy-java:8080/health/sg_a7a20ae0
+  - id: sg_a8b629ef
+    title: Campaign launches start within the scheduled execution window
+    itemId: it_8f468246
+    url: http://dummy-python:8080/health/sg_a8b629ef
+  - id: sg_c4d54536
+    title: Availability heartbeat responds
+    itemId: it_b61910c1
+    url: http://dummy-javascript:8080/health/sg_c4d54536
+  - id: sg_ef4b1465
+    title: Request latency is within SLO
+    itemId: it_b61910c1
+    url: http://dummy-java:8080/health/sg_ef4b1465
+  - id: sg_f6d9f83f
+    title: Error rate is below threshold
+    itemId: it_b61910c1
+    url: http://dummy-python:8080/health/sg_f6d9f83f
+  - id: sg_165f3d24
+    title: Work backlog is within limits
+    itemId: it_b61910c1
+    url: http://dummy-javascript:8080/health/sg_165f3d24
+  - id: sg_817dadbc
+    title: Availability heartbeat responds
+    itemId: it_1151701c
+    url: http://dummy-java:8080/health/sg_817dadbc
+  - id: sg_8aef2e45
+    title: Availability heartbeat responds
+    itemId: it_2484e0db
+    url: http://dummy-python:8080/health/sg_8aef2e45
+  - id: sg_9e903159
+    title: Request latency is within SLO
+    itemId: it_2484e0db
+    url: http://dummy-javascript:8080/health/sg_9e903159
+  - id: sg_983d5874
+    title: Error rate is below threshold
+    itemId: it_2484e0db
+    url: http://dummy-java:8080/health/sg_983d5874
+  - id: sg_03c6a1d7
+    title: Availability heartbeat responds
+    itemId: it_fbb05062
+    url: http://dummy-python:8080/health/sg_03c6a1d7
+  - id: sg_982607cb
+    title: Request latency is within SLO
+    itemId: it_fbb05062
+    url: http://dummy-javascript:8080/health/sg_982607cb
+  - id: sg_207867b6
+    title: Error rate is below threshold
+    itemId: it_fbb05062
+    url: http://dummy-java:8080/health/sg_207867b6
+  - id: sg_d118f36e
+    title: Availability heartbeat responds
+    itemId: it_96952012
+    url: http://dummy-python:8080/health/sg_d118f36e
+  - id: sg_cb2a5e9e
+    title: Availability heartbeat responds
+    itemId: it_65839693
+    url: http://dummy-javascript:8080/health/sg_cb2a5e9e
+  - id: sg_3323b84d
+    title: Request latency is within SLO
+    itemId: it_65839693
+    url: http://dummy-java:8080/health/sg_3323b84d
+  - id: sg_905d300a
+    title: Error rate is below threshold
+    itemId: it_65839693
+    url: http://dummy-python:8080/health/sg_905d300a
+  - id: sg_435b9e95
+    title: Availability heartbeat responds
+    itemId: it_3ca8ec85
+    url: http://dummy-javascript:8080/health/sg_435b9e95
+  - id: sg_e7aed1f3
+    title: Request latency is within SLO
+    itemId: it_3ca8ec85
+    url: http://dummy-java:8080/health/sg_e7aed1f3
+  - id: sg_35012a6a
+    title: Error rate is below threshold
+    itemId: it_3ca8ec85
+    url: http://dummy-python:8080/health/sg_35012a6a
+  - id: sg_3833ef5f
+    title: Work backlog is within limits
+    itemId: it_3ca8ec85
+    url: http://dummy-javascript:8080/health/sg_3833ef5f
+  - id: sg_fe6e6f52
+    title: Availability heartbeat responds
+    itemId: it_4c046b1d
+    url: http://dummy-java:8080/health/sg_fe6e6f52
+  - id: sg_c598a588
+    title: Request latency is within SLO
+    itemId: it_4c046b1d
+    url: http://dummy-python:8080/health/sg_c598a588
+  - id: sg_3ec01427
+    title: Error rate is below threshold
+    itemId: it_4c046b1d
+    url: http://dummy-javascript:8080/health/sg_3ec01427
+  - id: sg_8a7bb91c
+    title: Work backlog is within limits
+    itemId: it_4c046b1d
+    url: http://dummy-java:8080/health/sg_8a7bb91c
+  - id: sg_78437c6e
+    title: Authorization decisions return within the allowed window
+    itemId: it_4c046b1d
+    url: http://dummy-python:8080/health/sg_78437c6e
+  - id: sg_2b0f9b2f
+    title: Availability heartbeat responds
+    itemId: it_9e60bdd7
+    url: http://dummy-javascript:8080/health/sg_2b0f9b2f
+  - id: sg_94a27eb5
+    title: Request latency is within SLO
+    itemId: it_9e60bdd7
+    url: http://dummy-java:8080/health/sg_94a27eb5
+  - id: sg_0777765c
+    title: Error rate is below threshold
+    itemId: it_9e60bdd7
+    url: http://dummy-python:8080/health/sg_0777765c
+  - id: sg_f8dc895c
+    title: Availability heartbeat responds
+    itemId: it_3160377e
+    url: http://dummy-javascript:8080/health/sg_f8dc895c
+  - id: sg_254d1967
+    title: Availability heartbeat responds
+    itemId: it_bd3e8b82
+    url: http://dummy-java:8080/health/sg_254d1967
+  - id: sg_14bfc6a9
+    title: Availability heartbeat responds
+    itemId: it_9ead5a94
+    url: http://dummy-python:8080/health/sg_14bfc6a9
+  - id: sg_4dd0ceab
+    title: Request latency is within SLO
+    itemId: it_9ead5a94
+    url: http://dummy-javascript:8080/health/sg_4dd0ceab
+  - id: sg_a103073b
+    title: Error rate is below threshold
+    itemId: it_9ead5a94
+    url: http://dummy-java:8080/health/sg_a103073b
+  - id: sg_4bfce491
+    title: Work backlog is within limits
+    itemId: it_9ead5a94
+    url: http://dummy-python:8080/health/sg_4bfce491
+  - id: sg_e481b86c
+    title: Availability heartbeat responds
+    itemId: it_9de17f36
+    url: http://dummy-javascript:8080/health/sg_e481b86c
+  - id: sg_7b55267d
+    title: Availability heartbeat responds
+    itemId: it_ed0d04bb
+    url: http://dummy-java:8080/health/sg_7b55267d
+  - id: sg_8dee7a3e
+    title: Request latency is within SLO
+    itemId: it_ed0d04bb
+    url: http://dummy-python:8080/health/sg_8dee7a3e
+  - id: sg_539fea23
+    title: Availability heartbeat responds
+    itemId: it_20cb3376
+    url: http://dummy-javascript:8080/health/sg_539fea23
+  - id: sg_0983f501
+    title: Availability heartbeat responds
+    itemId: it_7199280d
+    url: http://dummy-java:8080/health/sg_0983f501
+  - id: sg_cbd5e594
+    title: Request latency is within SLO
+    itemId: it_7199280d
+    url: http://dummy-python:8080/health/sg_cbd5e594
+  - id: sg_fe5cdfa1
+    title: Error rate is below threshold
+    itemId: it_7199280d
+    url: http://dummy-javascript:8080/health/sg_fe5cdfa1
+  - id: sg_bb7ca6be
+    title: Availability heartbeat responds
+    itemId: it_2df0c55c
+    url: http://dummy-java:8080/health/sg_bb7ca6be
+  - id: sg_02c9f5ab
+    title: Request latency is within SLO
+    itemId: it_2df0c55c
+    url: http://dummy-python:8080/health/sg_02c9f5ab
+  - id: sg_a903c47e
+    title: Availability heartbeat responds
+    itemId: it_116e2e82
+    url: http://dummy-javascript:8080/health/sg_a903c47e
+  - id: sg_ade3ed5b
+    title: Request latency is within SLO
+    itemId: it_116e2e82
+    url: http://dummy-java:8080/health/sg_ade3ed5b
+  - id: sg_4aff677c
+    title: Error rate is below threshold
+    itemId: it_116e2e82
+    url: http://dummy-python:8080/health/sg_4aff677c
+  - id: sg_d5788b91
+    title: Availability heartbeat responds
+    itemId: it_a6854c60
+    url: http://dummy-javascript:8080/health/sg_d5788b91
+  - id: sg_a9cd3eb7
+    title: Request latency is within SLO
+    itemId: it_a6854c60
+    url: http://dummy-java:8080/health/sg_a9cd3eb7
+  - id: sg_b3aea136
+    title: Error rate is below threshold
+    itemId: it_a6854c60
+    url: http://dummy-python:8080/health/sg_b3aea136
+  - id: sg_3254993b
+    title: Work backlog is within limits
+    itemId: it_a6854c60
+    url: http://dummy-javascript:8080/health/sg_3254993b
+  - id: sg_618ba555
+    title: Availability heartbeat responds
+    itemId: it_9c69814b
+    url: http://dummy-java:8080/health/sg_618ba555
+  - id: sg_654c5a8d
+    title: Request latency is within SLO
+    itemId: it_9c69814b
+    url: http://dummy-python:8080/health/sg_654c5a8d
+  - id: sg_9916732e
+    title: Error rate is below threshold
+    itemId: it_9c69814b
+    url: http://dummy-javascript:8080/health/sg_9916732e
+  - id: sg_987fe31d
+    title: Work backlog is within limits
+    itemId: it_9c69814b
+    url: http://dummy-java:8080/health/sg_987fe31d
+  - id: sg_f56a8ce5
+    title: Availability heartbeat responds
+    itemId: it_0c7f7cbf
+    url: http://dummy-python:8080/health/sg_f56a8ce5
+  - id: sg_3cfa0589
+    title: Request latency is within SLO
+    itemId: it_0c7f7cbf
+    url: http://dummy-javascript:8080/health/sg_3cfa0589
+  - id: sg_a0552469
+    title: Error rate is below threshold
+    itemId: it_0c7f7cbf
+    url: http://dummy-java:8080/health/sg_a0552469
+  - id: sg_8394e9c6
+    title: Availability heartbeat responds
+    itemId: it_40d8cd7c
+    url: http://dummy-python:8080/health/sg_8394e9c6
+  - id: sg_b6971819
+    title: Request latency is within SLO
+    itemId: it_40d8cd7c
+    url: http://dummy-javascript:8080/health/sg_b6971819
+  - id: sg_1890e867
+    title: Error rate is below threshold
+    itemId: it_40d8cd7c
+    url: http://dummy-java:8080/health/sg_1890e867
+  - id: sg_6be4a1ab
+    title: Availability heartbeat responds
+    itemId: it_12a5d380
+    url: http://dummy-python:8080/health/sg_6be4a1ab
+  - id: sg_63ff3568
+    title: Availability heartbeat responds
+    itemId: it_5e0132b8
+    url: http://dummy-javascript:8080/health/sg_63ff3568
+  - id: sg_efc3563f
+    title: Availability heartbeat responds
+    itemId: it_7e7405d3
+    url: http://dummy-java:8080/health/sg_efc3563f
+  - id: sg_c05a08f5
+    title: Availability heartbeat responds
+    itemId: it_6cab1e6f
+    url: http://dummy-python:8080/health/sg_c05a08f5
+  - id: sg_1e04a674
+    title: Request latency is within SLO
+    itemId: it_6cab1e6f
+    url: http://dummy-javascript:8080/health/sg_1e04a674
+  - id: sg_ade1ec4c
+    title: Error rate is below threshold
+    itemId: it_6cab1e6f
+    url: http://dummy-java:8080/health/sg_ade1ec4c
+  - id: sg_429bf17b
+    title: Availability heartbeat responds
+    itemId: it_984c1c25
+    url: http://dummy-python:8080/health/sg_429bf17b
+  - id: sg_4c0a51f4
+    title: Request latency is within SLO
+    itemId: it_984c1c25
+    url: http://dummy-javascript:8080/health/sg_4c0a51f4
+  - id: sg_f7f6edb5
+    title: Error rate is below threshold
+    itemId: it_984c1c25
+    url: http://dummy-java:8080/health/sg_f7f6edb5
+  - id: sg_5181baa7
+    title: Availability heartbeat responds
+    itemId: it_86ccee33
+    url: http://dummy-python:8080/health/sg_5181baa7
+  - id: sg_12d36cbd
+    title: Request latency is within SLO
+    itemId: it_86ccee33
+    url: http://dummy-javascript:8080/health/sg_12d36cbd
+  - id: sg_7f2737cb
+    title: Error rate is below threshold
+    itemId: it_86ccee33
+    url: http://dummy-java:8080/health/sg_7f2737cb
+  - id: sg_6ce78669
+    title: Work backlog is within limits
+    itemId: it_86ccee33
+    url: http://dummy-python:8080/health/sg_6ce78669
+  - id: sg_47eaac73
+    title: Availability heartbeat responds
+    itemId: it_29082314
+    url: http://dummy-javascript:8080/health/sg_47eaac73
+  - id: sg_a9db1e4e
+    title: "SLI: Customer-visible availability"
+    itemId: it_6307a2a8
+    url: http://dummy-java:8080/health/sg_a9db1e4e
+  - id: sg_b436fac9
+    title: "SLI: Customer journey latency"
+    itemId: it_6307a2a8
+    url: http://dummy-python:8080/health/sg_b436fac9
+  - id: sg_50e54bcf
+    title: "SLI: Customer-visible availability"
+    itemId: it_5b917d99
+    url: http://dummy-javascript:8080/health/sg_50e54bcf
+  - id: sg_42a2702e
+    title: "SLI: Customer-visible availability"
+    itemId: it_8be9ba4f
+    url: http://dummy-java:8080/health/sg_42a2702e
+  - id: sg_733d3676
+    title: "SLI: Customer-visible availability"
+    itemId: it_144bbdb0
+    url: http://dummy-python:8080/health/sg_733d3676
+  - id: sg_605ae23c
+    title: "SLI: Customer-visible availability"
+    itemId: it_008a7af7
+    url: http://dummy-javascript:8080/health/sg_605ae23c
+  - id: sg_244c2ec0
+    title: "SLI: Customer journey latency"
+    itemId: it_008a7af7
+    url: http://dummy-java:8080/health/sg_244c2ec0
+  - id: sg_b46914a3
+    title: "SLI: Customer-visible availability"
+    itemId: it_1668c093
+    url: http://dummy-python:8080/health/sg_b46914a3
+  - id: sg_772c3872
+    title: "SLI: Customer-visible availability"
+    itemId: it_6c7923ab
+    url: http://dummy-javascript:8080/health/sg_772c3872
+  - id: sg_cf952769
+    title: "SLI: Customer-visible availability"
+    itemId: it_43ab1049
+    url: http://dummy-java:8080/health/sg_cf952769
+  - id: sg_a72a7585
+    title: "SLI: Customer-visible availability"
+    itemId: it_571c410e
+    url: http://dummy-python:8080/health/sg_a72a7585
+  - id: sg_3c0e4f9f
+    title: "SLI: Customer journey latency"
+    itemId: it_571c410e
+    url: http://dummy-javascript:8080/health/sg_3c0e4f9f
+  - id: sg_93fcc5ab
+    title: "SLI: Customer-visible availability"
+    itemId: it_c51a1ccc
+    url: http://dummy-java:8080/health/sg_93fcc5ab
+  - id: sg_37f4f621
+    title: "SLI: Customer-visible availability"
+    itemId: it_0387f962
+    url: http://dummy-python:8080/health/sg_37f4f621
+  - id: sg_e8db7ae0
+    title: "SLI: Customer-visible availability"
+    itemId: it_978f32ea
+    url: http://dummy-javascript:8080/health/sg_e8db7ae0
+  - id: sg_a833ffd4
+    title: "SLI: Customer-visible availability"
+    itemId: it_ef57ee00
+    url: http://dummy-java:8080/health/sg_a833ffd4
+  - id: sg_8aac4012
+    title: "SLI: Customer journey latency"
+    itemId: it_ef57ee00
+    url: http://dummy-python:8080/health/sg_8aac4012
+  - id: sg_c6efd2ed
+    title: "SLI: Customer-visible availability"
+    itemId: it_906f7e0d
+    url: http://dummy-javascript:8080/health/sg_c6efd2ed
+  - id: sg_664f8659
+    title: "SLI: Customer-visible availability"
+    itemId: it_05c82f52
+    url: http://dummy-java:8080/health/sg_664f8659
+  - id: sg_edfba194
+    title: "SLI: Customer-visible availability"
+    itemId: it_5c743f44
+    url: http://dummy-python:8080/health/sg_edfba194
+  - id: sg_70e967e6
+    title: "SLI: Customer-visible availability"
+    itemId: it_741e7f6b
+    url: http://dummy-javascript:8080/health/sg_70e967e6
+  - id: sg_a405da69
+    title: "SLI: Customer journey latency"
+    itemId: it_741e7f6b
+    url: http://dummy-java:8080/health/sg_a405da69
+  - id: sg_5477a648
+    title: "SLI: Customer-visible availability"
+    itemId: it_6e67d308
+    url: http://dummy-python:8080/health/sg_5477a648
+  - id: sg_a5cad7ac
+    title: "SLI: Customer-visible availability"
+    itemId: it_d01a646d
+    url: http://dummy-javascript:8080/health/sg_a5cad7ac
+  - id: sg_cb610e2f
+    title: "SLI: Customer-visible availability"
+    itemId: it_bee18e53
+    url: http://dummy-java:8080/health/sg_cb610e2f
+  - id: sg_03092fad
+    title: "SLI: Customer-visible availability"
+    itemId: it_a0a28b85
+    url: http://dummy-python:8080/health/sg_03092fad
+  - id: sg_9575a8ad
+    title: "SLI: Customer journey latency"
+    itemId: it_a0a28b85
+    url: http://dummy-javascript:8080/health/sg_9575a8ad
+  - id: sg_6222e1a9
+    title: "SLI: Customer-visible availability"
+    itemId: it_4869434a
+    url: http://dummy-java:8080/health/sg_6222e1a9
+  - id: sg_63bde755
+    title: "SLI: Customer-visible availability"
+    itemId: it_e8e0d47a
+    url: http://dummy-python:8080/health/sg_63bde755
+  - id: sg_9a351852
+    title: "SLI: Customer-visible availability"
+    itemId: it_5622ffff
+    url: http://dummy-javascript:8080/health/sg_9a351852
+  - id: sg_042606b8
+    title: "SLI: Customer-visible availability"
+    itemId: it_5d0def3d
+    url: http://dummy-java:8080/health/sg_042606b8
+  - id: sg_026c2d21
+    title: "SLI: Customer journey latency"
+    itemId: it_5d0def3d
+    url: http://dummy-python:8080/health/sg_026c2d21
+  - id: sg_cb468f0c
+    title: "SLI: Customer-visible availability"
+    itemId: it_ccf17b90
+    url: http://dummy-javascript:8080/health/sg_cb468f0c
+  - id: sg_7b855c5b
+    title: "SLI: Customer-visible availability"
+    itemId: it_e6af80a7
+    url: http://dummy-java:8080/health/sg_7b855c5b
+  - id: sg_e7397b66
+    title: "SLI: Customer-visible availability"
+    itemId: it_352b4411
+    url: http://dummy-python:8080/health/sg_e7397b66
+  - id: sg_28a704c3
+    title: "SLI: Customer-visible availability"
+    itemId: it_ae13d093
+    url: http://dummy-javascript:8080/health/sg_28a704c3
+  - id: sg_ad3bf046
+    title: "SLI: Customer journey latency"
+    itemId: it_ae13d093
+    url: http://dummy-java:8080/health/sg_ad3bf046
+  - id: sg_0516885c
+    title: "SLI: Commerce entrypoints stay available for buyers"
+    itemId: it_e7f7ec2d
+    url: http://dummy-java:8080/health/sg_0516885c
+  - id: sg_9199929c
+    title: "SLI: Checkout journey latency stays within budget"
+    itemId: it_e7f7ec2d
+    url: http://dummy-java:8080/health/sg_9199929c
+  - id: sg_13d40a40
+    title: Order handling throughput sustains peak demand
+    itemId: it_e7f7ec2d
+    url: http://dummy-java:8080/health/sg_13d40a40
+  - id: sg_d289d808
+    title: "SLI: Customer touchpoints stay reachable end to end"
+    itemId: it_9d9e5627
+    url: http://dummy-java:8080/health/sg_d289d808
+  - id: sg_fc074e2b
+    title: "SLI: Engagement journey latency stays within target"
+    itemId: it_9d9e5627
+    url: http://dummy-java:8080/health/sg_fc074e2b
+  - id: sg_8e64cfe3
+    title: Customer-facing channels remain ready for traffic shifts
+    itemId: it_9d9e5627
+    url: http://dummy-java:8080/health/sg_8e64cfe3
+  - id: sg_2e0ea9da
+    title: "SLI: Operations workflows remain available to operators"
+    itemId: it_51dae4dd
+    url: http://dummy-java:8080/health/sg_2e0ea9da
+  - id: sg_bf331465
+    title: "SLI: Operator flow latency stays within control limits"
+    itemId: it_51dae4dd
+    url: http://dummy-java:8080/health/sg_bf331465
+  - id: sg_ccd3df0e
+    title: Operational cycle time stays within the expected envelope
+    itemId: it_51dae4dd
+    url: http://dummy-java:8080/health/sg_ccd3df0e
+  - id: sg_298b79ff
+    title: "SLI: Customer journey latency"
+    itemId: it_352b4411
+    url: http://dummy-java:8080/health/sg_298b79ff
+  - id: sg_1369d4b4
+    title: Produced output passes self-validation before publication
+    itemId: it_352b4411
+    url: http://dummy-java:8080/health/sg_1369d4b4
+  - id: sg_0e28ccaf
+    title: "SLI: Customer journey latency"
+    itemId: it_8be9ba4f
+    url: http://dummy-java:8080/health/sg_0e28ccaf
+  - id: sg_09223d5b
+    title: Own generated results pass internal self-validation
+    itemId: it_8be9ba4f
+    url: http://dummy-java:8080/health/sg_09223d5b
+  - id: sg_54850978
+    title: "SLI: Customer journey latency"
+    itemId: it_5b917d99
+    url: http://dummy-java:8080/health/sg_54850978
+  - id: sg_ace4d81c
+    title: Extension release path stays ready for controlled rollouts
+    itemId: it_5b917d99
+    url: http://dummy-java:8080/health/sg_ace4d81c
+  - id: sg_ff24943b
+    title: "SLI: Customer journey latency"
+    itemId: it_05c82f52
+    url: http://dummy-java:8080/health/sg_ff24943b
+  - id: sg_eafd7554
+    title: Internal state transitions remain self-consistent
+    itemId: it_05c82f52
+    url: http://dummy-java:8080/health/sg_eafd7554
+  - id: sg_0cf4fee8
+    title: "SLI: Customer journey latency"
+    itemId: it_6e67d308
+    url: http://dummy-java:8080/health/sg_0cf4fee8
+  - id: sg_05de9530
+    title: Critical engagement flows finish without internal stalls
+    itemId: it_6e67d308
+    url: http://dummy-java:8080/health/sg_05de9530
+  - id: sg_9546465d
+    title: "SLI: Customer journey latency"
+    itemId: it_5c743f44
+    url: http://dummy-java:8080/health/sg_9546465d
+  - id: sg_2af26ccb
+    title: Personalization signals stay within the freshness window
+    itemId: it_5c743f44
+    url: http://dummy-java:8080/health/sg_2af26ccb
+  - id: sg_2e8fdae0
+    title: "SLI: Customer journey latency"
+    itemId: it_0387f962
+    url: http://dummy-java:8080/health/sg_2e8fdae0
+  - id: sg_497d14ca
+    title: Own task queue turns over before local saturation
+    itemId: it_0387f962
+    url: http://dummy-java:8080/health/sg_497d14ca
+  - id: sg_909afa04
+    title: "SLI: Customer journey latency"
+    itemId: it_d01a646d
+    url: http://dummy-java:8080/health/sg_909afa04
+  - id: sg_0c5d6472
+    title: Journey rules are applied within the local decision budget
+    itemId: it_d01a646d
+    url: http://dummy-java:8080/health/sg_0c5d6472
+  - id: sg_c293d8ed
+    title: "SLI: Customer journey latency"
+    itemId: it_978f32ea
+    url: http://dummy-java:8080/health/sg_c293d8ed
+  - id: sg_ef3a7299
+    title: Planning cycles complete within the dispatch schedule window
+    itemId: it_978f32ea
+    url: http://dummy-java:8080/health/sg_ef3a7299
+  - id: sg_ad196f74
+    title: "SLI: Customer journey latency"
+    itemId: it_906f7e0d
+    url: http://dummy-java:8080/health/sg_ad196f74
+  - id: sg_7cfe0fc7
+    title: Local inventory state stays within acceptable drift
+    itemId: it_906f7e0d
+    url: http://dummy-java:8080/health/sg_7cfe0fc7
+  - id: sg_6ded6c51
+    title: "SLI: Customer journey latency"
+    itemId: it_ccf17b90
+    url: http://dummy-java:8080/health/sg_6ded6c51
+  - id: sg_aac88c37
+    title: Route selection stays accurate under current load
+    itemId: it_ccf17b90
+    url: http://dummy-java:8080/health/sg_aac88c37
+  - id: sg_04ff1182
+    title: "SLI: Customer journey latency"
+    itemId: it_e6af80a7
+    url: http://dummy-java:8080/health/sg_04ff1182
+  - id: sg_7b3278d2
+    title: Template payloads pass internal render validation
+    itemId: it_e6af80a7
+    url: http://dummy-java:8080/health/sg_7b3278d2
+  - id: sg_156cf522
+    title: "SLI: Customer journey latency"
+    itemId: it_c51a1ccc
+    url: http://dummy-java:8080/health/sg_156cf522
+  - id: sg_bb71dfe3
+    title: Acceleration routines stay ready for burst simulations
+    itemId: it_c51a1ccc
+    url: http://dummy-java:8080/health/sg_bb71dfe3
+  - id: sg_4a2a6350
+    title: "SLI: Customer journey latency"
+    itemId: it_144bbdb0
+    url: http://dummy-java:8080/health/sg_4a2a6350
+  - id: sg_73eb6069
+    title: Order state transitions remain internally consistent
+    itemId: it_144bbdb0
+    url: http://dummy-java:8080/health/sg_73eb6069
+  - id: sg_9cf1eb9e
+    title: "SLI: Customer journey latency"
+    itemId: it_6c7923ab
+    url: http://dummy-java:8080/health/sg_9cf1eb9e
+  - id: sg_2e65a0c3
+    title: Finance ledger updates stay internally balanced
+    itemId: it_6c7923ab
+    url: http://dummy-java:8080/health/sg_2e65a0c3
+  - id: sg_3a716594
+    title: "SLI: Customer journey latency"
+    itemId: it_1668c093
+    url: http://dummy-java:8080/health/sg_3a716594
+  - id: sg_837f4658
+    title: Guard policies cover the current intake mix
+    itemId: it_1668c093
+    url: http://dummy-java:8080/health/sg_837f4658
+  - id: sg_81544d92
+    title: "SLI: Customer journey latency"
+    itemId: it_43ab1049
+    url: http://dummy-java:8080/health/sg_81544d92
+  - id: sg_6bfa4484
+    title: Workflow stages advance without local stalls
+    itemId: it_43ab1049
+    url: http://dummy-java:8080/health/sg_6bfa4484
+  - id: sg_9b23436f
+    title: "SLI: Customer journey latency"
+    itemId: it_5622ffff
+    url: http://dummy-java:8080/health/sg_9b23436f
+  - id: sg_bcdd0ae2
+    title: Core profile merges pass internal validation
+    itemId: it_5622ffff
+    url: http://dummy-java:8080/health/sg_bcdd0ae2
+  - id: sg_b296a7d9
+    title: "SLI: Customer journey latency"
+    itemId: it_e8e0d47a
+    url: http://dummy-java:8080/health/sg_b296a7d9
+  - id: sg_f494da19
+    title: Campaign budget calculations stay current
+    itemId: it_e8e0d47a
+    url: http://dummy-java:8080/health/sg_f494da19
+  - id: sg_dda6b54a
+    title: "SLI: Customer journey latency"
+    itemId: it_bee18e53
+    url: http://dummy-java:8080/health/sg_dda6b54a
+  - id: sg_9f64018e
+    title: Session updates land before the expiry budget
+    itemId: it_bee18e53
+    url: http://dummy-java:8080/health/sg_9f64018e
+  - id: sg_f311c740
+    title: "SLI: Customer journey latency"
+    itemId: it_4869434a
+    url: http://dummy-java:8080/health/sg_f311c740
+  - id: sg_bb3b06cf
+    title: Messaging channels stay ready for delivery bursts
+    itemId: it_4869434a
+    url: http://dummy-java:8080/health/sg_bb3b06cf
+  - id: sg_6263669c
+    title: Optimization output passes internal quality gates
+    itemId: it_ae13d093
+    url: http://dummy-java:8080/health/sg_6263669c
+  - id: sg_1b8d1fee
+    title: Commerce line data stays fresh through the order window
+    itemId: it_6307a2a8
+    url: http://dummy-java:8080/health/sg_1b8d1fee
+  - id: sg_f7e64741
+    title: Experience foundation state stays within freshness targets
+    itemId: it_741e7f6b
+    url: http://dummy-java:8080/health/sg_f7e64741
+  - id: sg_ef68bf01
+    title: Routing plans stay stable during recalculation bursts
+    itemId: it_ef57ee00
+    url: http://dummy-java:8080/health/sg_ef68bf01
+  - id: sg_9fefa082
+    title: Operational workload stays balanced across local cycles
+    itemId: it_571c410e
+    url: http://dummy-java:8080/health/sg_9fefa082
+  - id: sg_7340b7fd
+    title: Intake backlog drains before local buffer pressure rises
+    itemId: it_008a7af7
+    url: http://dummy-java:8080/health/sg_7340b7fd
+  - id: sg_05f51923
+    title: Identity matching stays within the accepted confidence band
+    itemId: it_5d0def3d
+    url: http://dummy-java:8080/health/sg_05f51923
+  - id: sg_e18a5dcb
+    title: Profile enrichment finishes within the interaction budget
+    itemId: it_a0a28b85
+    url: http://dummy-java:8080/health/sg_e18a5dcb
+  - id: sg_30968032
+    title: "SLI: Client request latency is within SLO"
+    itemId: it_29082314
+    url: http://dummy-java:8080/health/sg_30968032
+  - id: sg_7de09a1a
+    title: Budget guardrail snapshots stay within the freshness window
+    itemId: it_29082314
+    url: http://dummy-java:8080/health/sg_7de09a1a
+  - id: sg_2ac441d9
+    title: "SLI: Client request latency is within SLO"
+    itemId: it_71574a7b
+    url: http://dummy-java:8080/health/sg_2ac441d9
+  - id: sg_6024a240
+    title: Orchestration state remains internally consistent
+    itemId: it_71574a7b
+    url: http://dummy-java:8080/health/sg_6024a240
+  - id: sg_a8a9d866
+    title: "SLI: Client request latency is within SLO"
+    itemId: it_96952012
+    url: http://dummy-java:8080/health/sg_a8a9d866
+  - id: sg_fe8157dc
+    title: Fraud scoring output passes internal quality thresholds
+    itemId: it_96952012
+    url: http://dummy-java:8080/health/sg_fe8157dc
+  - id: sg_9fff7e87
+    title: "SLI: Client request latency is within SLO"
+    itemId: it_bd3e8b82
+    url: http://dummy-java:8080/health/sg_9fff7e87
+  - id: sg_5f4f6229
+    title: Control-plane cycles finish within the operating window
+    itemId: it_bd3e8b82
+    url: http://dummy-java:8080/health/sg_5f4f6229
+  - id: sg_3dbdd5b5
+    title: "SLI: Client request latency is within SLO"
+    itemId: it_20cb3376
+    url: http://dummy-java:8080/health/sg_3dbdd5b5
+  - id: sg_8a3ff0b8
+    title: Reconciliation drift stays within the accepted band
+    itemId: it_20cb3376
+    url: http://dummy-java:8080/health/sg_8a3ff0b8
+  - id: sg_0585d690
+    title: "SLI: Client request latency is within SLO"
+    itemId: it_12a5d380
+    url: http://dummy-java:8080/health/sg_0585d690
+  - id: sg_bc964671
+    title: Experiment evaluation closes within the expected window
+    itemId: it_12a5d380
+    url: http://dummy-java:8080/health/sg_bc964671
+  - id: sg_35f08b65
+    title: "SLI: Client request latency is within SLO"
+    itemId: it_ca854f7f
+    url: http://dummy-java:8080/health/sg_35f08b65
+  - id: sg_3c45eaeb
+    title: Dispatch work queue drains before local saturation
+    itemId: it_ca854f7f
+    url: http://dummy-java:8080/health/sg_3c45eaeb
+  - id: sg_cddabb8d
+    title: "SLI: Client request latency is within SLO"
+    itemId: it_1151701c
+    url: http://dummy-java:8080/health/sg_cddabb8d
+  - id: sg_b5315e4f
+    title: Domain event publication stays within freshness bounds
+    itemId: it_1151701c
+    url: http://dummy-java:8080/health/sg_b5315e4f
+  - id: sg_a98a0672
+    title: "SLI: Client request latency is within SLO"
+    itemId: it_3160377e
+    url: http://dummy-java:8080/health/sg_a98a0672
+  - id: sg_14bc6791
+    title: Deadline calculations stay within the tolerance band
+    itemId: it_3160377e
+    url: http://dummy-java:8080/health/sg_14bc6791
+  - id: sg_3fc5bb5f
+    title: "SLI: Client request latency is within SLO"
+    itemId: it_7e7405d3
+    url: http://dummy-java:8080/health/sg_3fc5bb5f
+  - id: sg_643a2552
+    title: Merge orchestration stays internally consistent
+    itemId: it_7e7405d3
+    url: http://dummy-java:8080/health/sg_643a2552
+  - id: sg_efe40c26
+    title: "SLI: Client request latency is within SLO"
+    itemId: it_9de17f36
+    url: http://dummy-java:8080/health/sg_efe40c26
+  - id: sg_d96aaa6c
+    title: Cache writes complete before the freshness budget expires
+    itemId: it_9de17f36
+    url: http://dummy-java:8080/health/sg_d96aaa6c
+  - id: sg_eb9c5c56
+    title: "SLI: Client request latency is within SLO"
+    itemId: it_5e0132b8
+    url: http://dummy-java:8080/health/sg_eb9c5c56
+  - id: sg_ff4e3639
+    title: Session state refresh lands before the expiry window
+    itemId: it_5e0132b8
+    url: http://dummy-java:8080/health/sg_ff4e3639
+  - id: sg_6a13ea27
+    title: "SLI: Client-visible availability"
+    itemId: it_2df0c55c
+    url: http://dummy-java:8080/health/sg_6a13ea27
+  - id: sg_4e49b186
+    title: "SLI: Client-visible availability"
+    itemId: it_ed0d04bb
+    url: http://dummy-java:8080/health/sg_4e49b186
+  - id: sg_f7b653b0
+    title: Checkout capacity holds during promotional spikes
+    itemId: it_e7f7ec2d
+    url: http://dummy-python:8080/health/sg_f7b653b0
+  - id: sg_c015eea4
+    title: "SLI: Engagement response stays within journey budget"
+    itemId: it_9d9e5627
+    url: http://dummy-javascript:8080/health/sg_c015eea4
+  - id: sg_e379057a
+    title: Personalization decisions stay within the freshness window
+    itemId: it_9d9e5627
+    url: http://dummy-java:8080/health/sg_e379057a
+  - id: sg_333412bb
+    title: Campaign plans stay current through the execution window
+    itemId: it_352b4411
+    url: http://dummy-python:8080/health/sg_333412bb
+  - id: sg_16784f6b
+    title: Slot allocation completes within the dispatch window
+    itemId: it_05c82f52
+    url: http://dummy-javascript:8080/health/sg_16784f6b
+  - id: sg_3c9d0744
+    title: "SLI: Fulfillment flow availability stays above target"
+    itemId: it_0387f962
+    url: http://dummy-java:8080/health/sg_3c9d0744
+  - id: sg_c56dcd4a
+    title: Allocation outcomes stay within the accepted variance
+    itemId: it_0387f962
+    url: http://dummy-python:8080/health/sg_c56dcd4a
+  - id: sg_808e6b6b
+    title: "SLI: Operational response stays within cycle budget"
+    itemId: it_571c410e
+    url: http://dummy-javascript:8080/health/sg_808e6b6b
+  - id: sg_87f8f21b
+    title: Decision payloads stay fresh through the send window
+    itemId: it_71574a7b
+    url: http://dummy-java:8080/health/sg_87f8f21b
+  - id: sg_523afde7
+    title: "SLI: Reconciliation path availability stays above target"
+    itemId: it_20cb3376
+    url: http://dummy-python:8080/health/sg_523afde7
+  - id: sg_f95b81ed
+    title: Reconciliation batches complete within the close window
+    itemId: it_20cb3376
+    url: http://dummy-javascript:8080/health/sg_f95b81ed
+  - id: sg_0cf038cf
+    title: Dispatch routing stays within the accepted variance
+    itemId: it_ca854f7f
+    url: http://dummy-java:8080/health/sg_0cf038cf
+  - id: sg_bde2197e
+    title: "SLI: Cache write latency stays within budget"
+    itemId: it_9de17f36
+    url: http://dummy-python:8080/health/sg_bde2197e
+  - id: sg_090f6b9f
+    title: Cache write batches stay stable during burst updates
+    itemId: it_9de17f36
+    url: http://dummy-javascript:8080/health/sg_090f6b9f

--- a/services-core/catalog/catalog/empty/catalog-actors-contacts.yaml
+++ b/services-core/catalog/catalog/empty/catalog-actors-contacts.yaml
@@ -1,0 +1,2 @@
+# yaml-language-server: $schema=../schemas/catalog-actors-contacts.schema.yaml
+actorContacts: []

--- a/services-core/catalog/catalog/empty/catalog-actors.yaml
+++ b/services-core/catalog/catalog/empty/catalog-actors.yaml
@@ -1,0 +1,2 @@
+# yaml-language-server: $schema=../schemas/catalog-actors.schema.yaml
+actors: []

--- a/services-core/catalog/catalog/empty/catalog-contacts.yaml
+++ b/services-core/catalog/catalog/empty/catalog-contacts.yaml
@@ -1,0 +1,2 @@
+# yaml-language-server: $schema=../schemas/catalog-contacts.schema.yaml
+contacts: []

--- a/services-core/catalog/catalog/empty/catalog-dependencies.yaml
+++ b/services-core/catalog/catalog/empty/catalog-dependencies.yaml
@@ -1,0 +1,2 @@
+# yaml-language-server: $schema=../schemas/catalog-dependencies.schema.yaml
+dependencies: []

--- a/services-core/catalog/catalog/empty/catalog-item-actors.yaml
+++ b/services-core/catalog/catalog/empty/catalog-item-actors.yaml
@@ -1,0 +1,2 @@
+# yaml-language-server: $schema=../schemas/catalog-item-actors.schema.yaml
+itemActors: []

--- a/services-core/catalog/catalog/empty/catalog-item-contacts.yaml
+++ b/services-core/catalog/catalog/empty/catalog-item-contacts.yaml
@@ -1,0 +1,2 @@
+# yaml-language-server: $schema=../schemas/catalog-item-contacts.schema.yaml
+itemContacts: []

--- a/services-core/catalog/catalog/empty/catalog-items.yaml
+++ b/services-core/catalog/catalog/empty/catalog-items.yaml
@@ -1,0 +1,2 @@
+# yaml-language-server: $schema=../schemas/catalog-items.schema.yaml
+items: []

--- a/services-core/catalog/catalog/empty/signals-http-poll.yaml
+++ b/services-core/catalog/catalog/empty/signals-http-poll.yaml
@@ -1,0 +1,2 @@
+# yaml-language-server: $schema=../schemas/signals-http-poll.schema.yaml
+signals: []


### PR DESCRIPTION
- Added a complete demo catalog dataset with items, dependencies, signals, actors, and contacts for realistic end-to-end scenarios
- Defined actor, contact, and ownership mappings to simulate real operational structures and escalation paths
- Introduced HTTP-based signal definitions to emulate service health and product-level SLIs in the demo environment
- Added a fully empty catalog dataset with all required schema files initialized to empty collections
- Ensured both datasets follow the same schema structure for interchangeable use across environments

## Result
- Demo environment can showcase realistic product health scenarios with meaningful topology, signals, and ownership context
- Empty dataset provides a clean baseline for custom setups, testing, or gradual catalog construction
- Enables switching between “out-of-the-box demo” and “from-scratch configuration” without code changes