### PR TITLE
Configure demo catalog variant in compose overlays

### DIFF
--- a/compose.overlay.demo-services-local-ports.yaml
+++ b/compose.overlay.demo-services-local-ports.yaml
@@ -10,3 +10,7 @@ services:
   dummy-javascript:
     ports:
       - "8083:8080"
+
+  catalog:
+    ports:
+      - "8084:8080"

--- a/compose.overlay.demo-services.yaml
+++ b/compose.overlay.demo-services.yaml
@@ -1,4 +1,13 @@
 services:
+  catalog:
+    environment:
+      CATALOG_DIR: ./catalog/demo
+
+  chaos-maker:
+    depends_on:
+      catalog:
+        condition: service_healthy
+
   dummy-java:
     logging:
       driver: json-file


### PR DESCRIPTION
- Configured catalog service to use demo dataset via `CATALOG_DIR` in demo overlays
- Exposed catalog service on a dedicated local port for demo access
- Added catalog service dependency for chaos-maker to ensure proper startup order
- Integrated catalog service into demo-specific compose overlays without affecting base setup

## Result
- Demo environment now runs with a realistic catalog dataset out of the box
- Catalog service is accessible and observable during local demo runs
- Service startup is coordinated to avoid race conditions in demo scenarios
- Clear separation between empty and demo catalog configurations