### PR TITLE
Switch demo environments to use catalog API

### DIFF
--- a/compose.demo.yaml
+++ b/compose.demo.yaml
@@ -4,31 +4,11 @@ services:
       FEEDBACK_STORAGE_CONFIG: ${FEEDBACK_STORAGE_CONFIG:?Missing FEEDBACK_STORAGE_CONFIG}
       ADMIN_USERNAME: ${ADMIN_USERNAME:?Missing ADMIN_USERNAME}
       ADMIN_PASSWORD: ${ADMIN_PASSWORD:?Missing ADMIN_PASSWORD}
-    build:
-      args:
-        CONTAINER_ROOT: services-core/aggregator
-        CATALOG_ITEMS_FILE: config/demo/catalog-items.yaml
-        CATALOG_DEPENDENCIES_FILE: config/demo/catalog-dependencies.yaml
-        SIGNALS_HTTP_POLL_FILE: config/demo/signals-http-poll.yaml
-        CATALOG_ITEMS_SCHEMA_FILE: config/schemas/catalog-items.schema.yaml
-        CATALOG_DEPENDENCIES_SCHEMA_FILE: config/schemas/catalog-dependencies.schema.yaml
-        SIGNALS_HTTP_POLL_SCHEMA_FILE: config/schemas/signals-http-poll.schema.yaml
-    volumes:
-      - ./config/demo:/app/config/demo:ro
-
+      CATALOG_BASE_URL: http://catalog:8080
   aggregator-ui:
     build:
-      context: .
-      dockerfile: services-core/aggregator-ui/Dockerfile
+      context: services-core/aggregator-ui
       args:
-        CONTAINER_ROOT: services-core/aggregator-ui
-        CATALOG_ITEMS_FILE: config/demo/catalog-items.yaml
-        CATALOG_DEPENDENCIES_FILE: config/demo/catalog-dependencies.yaml
-        CATALOG_CONTACTS_FILE: config/demo/catalog-contacts.yaml
-        CATALOG_ITEM_CONTACTS_FILE: config/demo/catalog-item-contacts.yaml
-        CATALOG_ACTORS_FILE: config/demo/catalog-actors.yaml
-        CATALOG_ITEM_ACTORS_FILE: config/demo/catalog-item-actors.yaml
-        CATALOG_ACTORS_CONTACTS_FILE: config/demo/catalog-actors-contacts.yaml
         VITE_APP_TITLE: "Health Aggregator DEMO"
 
   chaos-maker:
@@ -38,11 +18,7 @@ services:
         max-size: "10m"
         max-file: "5"
     build:
-      context: .
-      dockerfile: services-demo/chaos-maker/Dockerfile
-      args:
-        CONTAINER_ROOT: services-demo/chaos-maker
-        SIGNALS_HTTP_POLL_FILE: config/demo/signals-http-poll.yaml
+      context: services-demo/chaos-maker
     environment:
       CHAOS_ENABLED: "true"
       CHAOS_ALWAYS_BROKEN: "true"
@@ -51,8 +27,7 @@ services:
       CHAOS_MIN_DURATION: 5m
       CHAOS_MAX_DURATION: 60m
       CHAOS_MAX_CONCURRENT: "2"
-    volumes:
-      - ./config/demo:/config/demo:ro
+      CATALOG_SIGNALS_URL: http://catalog:8080/api/signals/http-poll
 
   prometheus:
     command:

--- a/compose.local-demo.yaml
+++ b/compose.local-demo.yaml
@@ -4,32 +4,14 @@ services:
       FEEDBACK_STORAGE_CONFIG: '{"type":"local","local":{"path":"/home/appuser/feedback/feedback.ndjson"}}'
       ADMIN_USERNAME: ${ADMIN_USERNAME:-admin}
       ADMIN_PASSWORD: ${ADMIN_PASSWORD:-admin}
-    build:
-      args:
-        CONTAINER_ROOT: services-core/aggregator
-        CATALOG_ITEMS_FILE: config/demo/catalog-items.yaml
-        CATALOG_DEPENDENCIES_FILE: config/demo/catalog-dependencies.yaml
-        SIGNALS_HTTP_POLL_FILE: config/demo/signals-http-poll.yaml
-        CATALOG_ITEMS_SCHEMA_FILE: config/schemas/catalog-items.schema.yaml
-        CATALOG_DEPENDENCIES_SCHEMA_FILE: config/schemas/catalog-dependencies.schema.yaml
-        SIGNALS_HTTP_POLL_SCHEMA_FILE: config/schemas/signals-http-poll.schema.yaml
+      CATALOG_BASE_URL: http://catalog:8080
     volumes:
-      - ./config/demo:/app/config/demo:ro
       - feedback-data:/home/appuser/feedback
 
   aggregator-ui:
     build:
-      context: .
-      dockerfile: services-core/aggregator-ui/Dockerfile
+      context: services-core/aggregator-ui
       args:
-        CONTAINER_ROOT: services-core/aggregator-ui
-        CATALOG_ITEMS_FILE: config/demo/catalog-items.yaml
-        CATALOG_DEPENDENCIES_FILE: config/demo/catalog-dependencies.yaml
-        CATALOG_CONTACTS_FILE: config/demo/catalog-contacts.yaml
-        CATALOG_ITEM_CONTACTS_FILE: config/demo/catalog-item-contacts.yaml
-        CATALOG_ACTORS_FILE: config/demo/catalog-actors.yaml
-        CATALOG_ITEM_ACTORS_FILE: config/demo/catalog-item-actors.yaml
-        CATALOG_ACTORS_CONTACTS_FILE: config/demo/catalog-actors-contacts.yaml
         VITE_APP_TITLE: "Health Aggregator LOCAL DEMO"
         VITE_TIMELINE_DEFAULT_RANGE: "15m"
 
@@ -40,11 +22,7 @@ services:
         max-size: "10m"
         max-file: "5"
     build:
-      context: .
-      dockerfile: services-demo/chaos-maker/Dockerfile
-      args:
-        CONTAINER_ROOT: services-demo/chaos-maker
-        SIGNALS_HTTP_POLL_FILE: config/demo/signals-http-poll.yaml
+      context: services-demo/chaos-maker
     environment:
       CHAOS_ENABLED: "true"
       CHAOS_ALWAYS_BROKEN: "true"
@@ -53,8 +31,7 @@ services:
       CHAOS_MIN_DURATION: 20s
       CHAOS_MAX_DURATION: 45s
       CHAOS_MAX_CONCURRENT: "2"
-    volumes:
-      - ./config/demo:/config/demo:ro
+      CATALOG_SIGNALS_URL: http://catalog:8080/api/signals/http-poll
 
   prometheus:
     image: prom/prometheus:v2.54.1


### PR DESCRIPTION
- Replaced file-based catalog configuration in aggregator with `CATALOG_BASE_URL`
- Updated aggregator-ui to remove direct catalog file wiring and rely on API-backed data
- Updated chaos-maker to fetch signals via catalog API instead of mounted files
- Removed demo config volume mounts previously used for catalog and signals
- Simplified service build configuration by eliminating catalog-related build args

## Result
- Demo environments now use catalog as a single source of truth via API
- Services are decoupled from local file-based configuration
- Compose setup is cleaner and closer to real service interaction model
- Demo and local demo behave consistently with production-like architecture