### PR TITLE
Simplify service image build contexts

### DIFF
--- a/services-core/aggregator-ui/Dockerfile
+++ b/services-core/aggregator-ui/Dockerfile
@@ -1,7 +1,6 @@
 # -------- Build stage --------
 FROM node:20-alpine AS build
 
-ARG CONTAINER_ROOT=.
 ARG VITE_APP_TITLE
 ARG VITE_TIMELINE_DEFAULT_RANGE
 
@@ -10,33 +9,18 @@ WORKDIR /app
 ENV VITE_APP_TITLE=${VITE_APP_TITLE:-}
 ENV VITE_TIMELINE_DEFAULT_RANGE=${VITE_TIMELINE_DEFAULT_RANGE:-1d}
 
-COPY ${CONTAINER_ROOT}/package.json ${CONTAINER_ROOT}/package-lock.json ./
+COPY package.json package-lock.json ./
 RUN --mount=type=cache,target=/root/.npm npm ci --no-audit --no-fund
 
-COPY ${CONTAINER_ROOT}/ ./
+COPY . ./
 RUN test -n "$VITE_TIMELINE_DEFAULT_RANGE"
 RUN npm run build
 
 # -------- Runtime stage --------
 FROM caddy:2-alpine
 
-ARG CATALOG_ITEMS_FILE
-ARG CATALOG_DEPENDENCIES_FILE
-ARG CATALOG_CONTACTS_FILE
-ARG CATALOG_ITEM_CONTACTS_FILE
-ARG CATALOG_ACTORS_FILE
-ARG CATALOG_ITEM_ACTORS_FILE
-ARG CATALOG_ACTORS_CONTACTS_FILE
-
 COPY --from=build /app/dist /usr/share/caddy
 COPY --from=build /app/Caddyfile /etc/caddy/Caddyfile
-COPY ${CATALOG_ITEMS_FILE} /usr/share/caddy/catalog-items.yaml
-COPY ${CATALOG_DEPENDENCIES_FILE} /usr/share/caddy/catalog-dependencies.yaml
-COPY ${CATALOG_CONTACTS_FILE} /usr/share/caddy/catalog-contacts.yaml
-COPY ${CATALOG_ITEM_CONTACTS_FILE} /usr/share/caddy/catalog-item-contacts.yaml
-COPY ${CATALOG_ACTORS_FILE} /usr/share/caddy/catalog-actors.yaml
-COPY ${CATALOG_ITEM_ACTORS_FILE} /usr/share/caddy/catalog-item-actors.yaml
-COPY ${CATALOG_ACTORS_CONTACTS_FILE} /usr/share/caddy/catalog-actors-contacts.yaml
 
 EXPOSE 3000
 ENTRYPOINT ["caddy", "run", "--config", "/etc/caddy/Caddyfile"]

--- a/services-core/aggregator/Dockerfile
+++ b/services-core/aggregator/Dockerfile
@@ -1,35 +1,20 @@
 # -------- Build stage --------
 FROM maven:3.9-eclipse-temurin-25 AS build
 
-ARG CONTAINER_ROOT=.
-
 WORKDIR /app
 
-COPY ${CONTAINER_ROOT}/pom.xml ./
+COPY pom.xml ./
 RUN mvn -B dependency:go-offline
 
-COPY ${CONTAINER_ROOT}/src ./src
+COPY src ./src
 RUN mvn -B package -DskipTests
 
 # -------- Runtime stage --------
 FROM eclipse-temurin:25-jre-jammy
 
-ARG CATALOG_ITEMS_FILE
-ARG CATALOG_DEPENDENCIES_FILE
-ARG SIGNALS_HTTP_POLL_FILE
-ARG CATALOG_ITEMS_SCHEMA_FILE
-ARG CATALOG_DEPENDENCIES_SCHEMA_FILE
-ARG SIGNALS_HTTP_POLL_SCHEMA_FILE
-
 WORKDIR /app
 
 COPY --from=build /app/target/*.jar ./app.jar
-COPY ${CATALOG_ITEMS_FILE} ./catalog-items.yaml
-COPY ${CATALOG_DEPENDENCIES_FILE} ./catalog-dependencies.yaml
-COPY ${SIGNALS_HTTP_POLL_FILE} ./signals-http-poll.yaml
-COPY ${CATALOG_ITEMS_SCHEMA_FILE} ./schemas/catalog-items.schema.yaml
-COPY ${CATALOG_DEPENDENCIES_SCHEMA_FILE} ./schemas/catalog-dependencies.schema.yaml
-COPY ${SIGNALS_HTTP_POLL_SCHEMA_FILE} ./schemas/signals-http-poll.schema.yaml
 
 RUN useradd --system --uid 1001 --create-home appuser \
   && mkdir -p /home/appuser/feedback \

--- a/services-demo/chaos-maker/Dockerfile
+++ b/services-demo/chaos-maker/Dockerfile
@@ -1,12 +1,8 @@
 FROM python:3.11-slim
 
-ARG CONTAINER_ROOT=.
-ARG SIGNALS_HTTP_POLL_FILE
-
 WORKDIR /app
 
-COPY ${CONTAINER_ROOT}/src ./
-COPY ${SIGNALS_HTTP_POLL_FILE} ./signals-http-poll.yaml
+COPY src ./
 
 RUN python -m venv /opt/venv \
  && /opt/venv/bin/pip install --no-cache-dir -r requirements.txt


### PR DESCRIPTION
- Removed `CONTAINER_ROOT` usage and switched to direct build contexts for all services
- Simplified Dockerfiles to copy sources directly from local context instead of parametrized paths
- Eliminated catalog and signal file injection into aggregator and UI images
- Removed signals file injection from chaos-maker image
- Reduced Docker build arguments across aggregator, UI, and chaos-maker

## Result
- Dockerfiles are simpler and easier to understand and maintain
- Image builds are less error-prone and no longer depend on external file wiring
- Services are fully decoupled from static file-based configuration at build time
- Build setup aligns with service-based runtime configuration via APIs