### PR TITLE
Switch catalog loading to API-based endpoints

### DIFF
--- a/services-core/aggregator/src/main/java/com/github/vermucht/aggregator/catalog/configuration/CatalogConfiguration.java
+++ b/services-core/aggregator/src/main/java/com/github/vermucht/aggregator/catalog/configuration/CatalogConfiguration.java
@@ -28,29 +28,17 @@ public class CatalogConfiguration {
       @Nonnull CatalogLoader catalogLoader,
       @Nonnull CatalogValidator catalogValidator,
       @Nonnull CatalogProperties properties) {
-    String itemsPath = properties.getItemsPath();
+    String itemsPath = properties.getItemsUrl();
     Resource itemsResource = resourceLoader.getResource(itemsPath);
     if (!itemsResource.exists()) {
       throw new IllegalStateException("Catalog items file not found at " + itemsPath);
     }
-    String dependenciesPath = properties.getDependenciesPath();
+    String dependenciesPath = properties.getDependenciesUrl();
     Resource dependenciesResource = resourceLoader.getResource(dependenciesPath);
     if (!dependenciesResource.exists()) {
       throw new IllegalStateException("Catalog dependencies file not found at " + dependenciesPath);
     }
-    String itemsSchemaPath = properties.getItemsSchemaPath();
-    Resource itemsSchemaResource = resourceLoader.getResource(itemsSchemaPath);
-    if (!itemsSchemaResource.exists()) {
-      throw new IllegalStateException("Catalog items schema file not found at " + itemsSchemaPath);
-    }
-    String dependenciesSchemaPath = properties.getDependenciesSchemaPath();
-    Resource dependenciesSchemaResource = resourceLoader.getResource(dependenciesSchemaPath);
-    if (!dependenciesSchemaResource.exists()) {
-      throw new IllegalStateException(
-          "Catalog dependencies schema file not found at " + dependenciesSchemaPath);
-    }
     return catalogValidator.validate(
-        catalogLoader.loadDefinition(
-            itemsResource, dependenciesResource, itemsSchemaResource, dependenciesSchemaResource));
+        catalogLoader.loadDefinition(itemsResource, dependenciesResource));
   }
 }

--- a/services-core/aggregator/src/main/java/com/github/vermucht/aggregator/catalog/configuration/CatalogLoader.java
+++ b/services-core/aggregator/src/main/java/com/github/vermucht/aggregator/catalog/configuration/CatalogLoader.java
@@ -25,24 +25,17 @@ public class CatalogLoader {
    *
    * @param itemsResource catalog items definition resource
    * @param dependenciesResource catalog dependencies definition resource
-   * @param itemsSchemaResource catalog items schema resource
-   * @param dependenciesSchemaResource catalog dependencies schema resource
    * @return merged catalog definition
    */
   @Nonnull
   public CatalogDefinition loadDefinition(
-      @Nonnull Resource itemsResource,
-      @Nonnull Resource dependenciesResource,
-      @Nonnull Resource itemsSchemaResource,
-      @Nonnull Resource dependenciesSchemaResource) {
+      @Nonnull Resource itemsResource, @Nonnull Resource dependenciesResource) {
     CatalogDefinition.CatalogItemsDefinition itemsDefinition =
         definitionLoader.loadDefinition(
-            itemsResource, itemsSchemaResource, CatalogDefinition.CatalogItemsDefinition.class);
+            itemsResource, CatalogDefinition.CatalogItemsDefinition.class);
     CatalogDefinition.CatalogDependenciesDefinition dependenciesDefinition =
         definitionLoader.loadDefinition(
-            dependenciesResource,
-            dependenciesSchemaResource,
-            CatalogDefinition.CatalogDependenciesDefinition.class);
+            dependenciesResource, CatalogDefinition.CatalogDependenciesDefinition.class);
     return new CatalogDefinition(itemsDefinition.items(), dependenciesDefinition.dependencies());
   }
 }

--- a/services-core/aggregator/src/main/java/com/github/vermucht/aggregator/catalog/configuration/CatalogProperties.java
+++ b/services-core/aggregator/src/main/java/com/github/vermucht/aggregator/catalog/configuration/CatalogProperties.java
@@ -1,44 +1,36 @@
 package com.github.vermucht.aggregator.catalog.configuration;
 
+import java.util.Objects;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-/** Configuration properties for catalog definition and schema resources. */
+/** Configuration properties for catalog service access. */
 @ConfigurationProperties("catalog")
 public class CatalogProperties {
-  private String itemsPath = "";
-  private String dependenciesPath = "";
-  private String itemsSchemaPath = "";
-  private String dependenciesSchemaPath = "";
+  private String baseUrl = "http://catalog:8080";
 
-  public String getItemsPath() {
-    return itemsPath;
+  public String getBaseUrl() {
+    return baseUrl;
   }
 
-  public void setItemsPath(String itemsPath) {
-    this.itemsPath = itemsPath;
+  public void setBaseUrl(String baseUrl) {
+    this.baseUrl = Objects.requireNonNullElse(baseUrl, "").trim();
   }
 
-  public String getDependenciesPath() {
-    return dependenciesPath;
+  public String getItemsUrl() {
+    return withPath("/api/catalog/items");
   }
 
-  public void setDependenciesPath(String dependenciesPath) {
-    this.dependenciesPath = dependenciesPath;
+  public String getDependenciesUrl() {
+    return withPath("/api/catalog/dependencies");
   }
 
-  public String getItemsSchemaPath() {
-    return itemsSchemaPath;
+  public String getSignalsUrl() {
+    return withPath("/api/signals/http-poll");
   }
 
-  public void setItemsSchemaPath(String itemsSchemaPath) {
-    this.itemsSchemaPath = itemsSchemaPath;
-  }
-
-  public String getDependenciesSchemaPath() {
-    return dependenciesSchemaPath;
-  }
-
-  public void setDependenciesSchemaPath(String dependenciesSchemaPath) {
-    this.dependenciesSchemaPath = dependenciesSchemaPath;
+  private String withPath(String path) {
+    String normalized =
+        baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
+    return normalized + path;
   }
 }

--- a/services-core/aggregator/src/main/java/com/github/vermucht/aggregator/catalog/configuration/RuntimeConfigurationReloader.java
+++ b/services-core/aggregator/src/main/java/com/github/vermucht/aggregator/catalog/configuration/RuntimeConfigurationReloader.java
@@ -60,27 +60,17 @@ public class RuntimeConfigurationReloader {
 
   /** Reloads catalog snapshot from configured item/dependency resources. */
   public void reloadCatalog() {
-    Resource itemsResource =
-        requireResource(catalogProperties.getItemsPath(), "Catalog items file");
+    Resource itemsResource = requireResource(catalogProperties.getItemsUrl(), "Catalog items file");
     Resource dependenciesResource =
-        requireResource(catalogProperties.getDependenciesPath(), "Catalog dependencies file");
-    Resource itemsSchemaResource =
-        requireResource(catalogProperties.getItemsSchemaPath(), "Catalog items schema file");
-    Resource dependenciesSchemaResource =
-        requireResource(
-            catalogProperties.getDependenciesSchemaPath(), "Catalog dependencies schema file");
+        requireResource(catalogProperties.getDependenciesUrl(), "Catalog dependencies file");
 
     Catalog reloadedCatalog =
         catalogValidator.validate(
-            catalogLoader.loadDefinition(
-                itemsResource,
-                dependenciesResource,
-                itemsSchemaResource,
-                dependenciesSchemaResource));
+            catalogLoader.loadDefinition(itemsResource, dependenciesResource));
     catalogRegistry.replaceCatalog(reloadedCatalog);
   }
 
-  /** Reloads signal sources snapshot from configured signal definition and schema. */
+  /** Reloads signal sources snapshot from configured signal definition resource. */
   public void reloadSignals() {
     Catalog currentCatalog = catalogRegistry.getCatalog();
     signalSourceRegistry.replaceSignalSources(


### PR DESCRIPTION
- Replaced file-based catalog paths with URL-based configuration derived from a single base URL
- Implemented endpoint resolution for items, dependencies, and signals using `CATALOG_BASE_URL`
- Removed schema resource handling from catalog loader and configuration
- Simplified catalog loading logic to consume only definition resources
- Updated runtime reload logic to fetch catalog and signals from API endpoints

## Result
- Aggregator now retrieves catalog data via service API instead of local files
- Configuration is simplified to a single base URL instead of multiple file paths
- Reduced complexity in catalog loading and validation flow
- Runtime configuration aligns with service-oriented architecture