### PR TITLE
Replace catalog path configuration with base URL setting

### DIFF
--- a/services-core/aggregator/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/services-core/aggregator/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -16,19 +16,9 @@
       "description": "Admin password for feedback admin endpoint HTTP Basic authentication."
     },
     {
-      "name": "catalog.items-schema-path",
+      "name": "catalog.base-url",
       "type": "java.lang.String",
-      "description": "Resource path to the catalog items JSON schema used to materialize defaults."
-    },
-    {
-      "name": "catalog.dependencies-schema-path",
-      "type": "java.lang.String",
-      "description": "Resource path to the catalog dependencies JSON schema used to materialize defaults."
-    },
-    {
-      "name": "health.http-poll.schema-path",
-      "type": "java.lang.String",
-      "description": "Resource path to the HTTP polling signals JSON schema used to materialize defaults."
+      "description": "Base URL of catalog service API, for example http://catalog:8080."
     }
   ]
 }

--- a/services-core/aggregator/src/main/resources/application.yaml
+++ b/services-core/aggregator/src/main/resources/application.yaml
@@ -9,15 +9,7 @@ management:
           - prometheus
 
 catalog:
-  items-path: file:./catalog-items.yaml
-  dependencies-path: file:./catalog-dependencies.yaml
-  items-schema-path: file:./schemas/catalog-items.schema.yaml
-  dependencies-schema-path: file:./schemas/catalog-dependencies.schema.yaml
-
-health:
-  http-poll:
-    definition-path: file:./signals-http-poll.yaml
-    schema-path: file:./schemas/signals-http-poll.schema.yaml
+  base-url: ${CATALOG_BASE_URL:http://catalog:8080}
 
 feedback:
   admin:


### PR DESCRIPTION
- Replaced multiple catalog file path settings with a single `catalog.base-url` configuration
- Removed schema-related configuration properties from application settings
- Updated default configuration to resolve catalog service URL via `CATALOG_BASE_URL` environment variable
- Simplified Spring configuration metadata to reflect API-based catalog access

## Result
- Configuration is reduced to a single entry point for catalog integration
- Eliminates need to manage multiple file and schema paths
- Aligns application configuration with API-driven catalog service
- Improves clarity and maintainability of configuration setup