### PR TITLE
Reformat ownership and signal chips into structured two-line layout

### DIFF
--- a/services-core/aggregator-ui/src/components/DetailsPanel.tsx
+++ b/services-core/aggregator-ui/src/components/DetailsPanel.tsx
@@ -393,7 +393,6 @@ export default function DetailsPanel({
               role="group"
               aria-label="Ownership"
             >
-              <p className="ownership-label">Owner</p>
               {ownerActorForContacts ? (
                 <a
                   className="ownership-owner-value"
@@ -409,8 +408,17 @@ export default function DetailsPanel({
                     ownerActorForContacts.title || ownerActorForContacts.id
                   }
                 >
-                  {renderActorTeamIcon(iconSpriteHref)}
-                  {ownerActorForContacts.title || ownerActorForContacts.id}
+                  <span className="chip-entry">
+                    <span className="chip-icon-block">
+                      {renderActorTeamIcon(iconSpriteHref)}
+                    </span>
+                    <span className="chip-text-block">
+                      <span className="chip-prefix">Owner</span>
+                      <span className="ownership-contact-value">
+                        {ownerActorForContacts.title || ownerActorForContacts.id}
+                      </span>
+                    </span>
+                  </span>
                 </a>
               ) : (
                 <p className="ownership-empty">No owner linked to this item</p>
@@ -418,7 +426,6 @@ export default function DetailsPanel({
 
               {primaryContact && (
                 <div className="ownership-contact-section">
-                  <p className="ownership-label">Primary contact</p>
                   <a
                     className="ownership-contact-row"
                     href={
@@ -433,9 +440,16 @@ export default function DetailsPanel({
                     }}
                     title={resolveContactLabel(primaryContact)}
                   >
-                    {renderContactTypeIcon(iconSpriteHref, primaryContact.type)}
-                    <span className="ownership-contact-value">
-                      {resolveContactLabel(primaryContact)}
+                    <span className="chip-entry">
+                      <span className="chip-icon-block">
+                        {renderContactTypeIcon(iconSpriteHref, primaryContact.type)}
+                      </span>
+                      <span className="chip-text-block">
+                        <span className="chip-prefix">Primary contact</span>
+                        <span className="ownership-contact-value">
+                          {resolveContactLabel(primaryContact)}
+                        </span>
+                      </span>
                     </span>
                   </a>
                 </div>
@@ -486,13 +500,17 @@ export default function DetailsPanel({
                             }}
                             title={entry.actor.title || entry.actor.id}
                           >
-                            {renderActorTeamIcon(iconSpriteHref)}
-                            <span className="ownership-actor-main">
-                              <span className="ownership-actor-type-label">
-                                {entry.typeLabel}
+                            <span className="chip-entry">
+                              <span className="chip-icon-block">
+                                {renderActorTeamIcon(iconSpriteHref)}
                               </span>
-                              <span className="ownership-contact-value">
-                                {entry.actor.title || entry.actor.id}
+                              <span className="chip-text-block">
+                                <span className="chip-prefix">
+                                {entry.typeLabel}
+                                </span>
+                                <span className="ownership-contact-value">
+                                  {entry.actor.title || entry.actor.id}
+                                </span>
                               </span>
                             </span>
                           </a>
@@ -539,20 +557,22 @@ export default function DetailsPanel({
                       <ul className="signals-list signals-sublist signals-group-list">
                         {selectedFailingSignals.map((entry) => (
                           <li key={entry.id} className="signal">
-                            <div className="signal-row">
-                              <span
-                                className={`status-indicator status-${entry.status}`}
-                                aria-label={buildStatusText(entry.status)}
-                                title={buildStatusText(entry.status)}
-                              />
-                              <span className="signals-incident-signal-prefix">
-                                Own
+                            <div className="signals-incident-title">
+                              <span className="signals-incident-indicator-wrap">
+                                <span
+                                  className={`status-indicator status-${entry.status}`}
+                                  aria-label={buildStatusText(entry.status)}
+                                  title={buildStatusText(entry.status)}
+                                />
                               </span>
-                              <span
-                                className="signal-name"
-                                title={entry.title || entry.id}
-                              >
-                                {entry.title || entry.id}
+                              <span className="signals-incident-text-stack">
+                                <span className="signals-incident-kind">Own</span>
+                                <span
+                                  className="signal-name"
+                                  title={entry.title || entry.id}
+                                >
+                                  {entry.title || entry.id}
+                                </span>
                               </span>
                             </div>
                           </li>
@@ -566,16 +586,20 @@ export default function DetailsPanel({
                         onClick={row.onClick}
                       >
                         <div className="signals-incident-title">
-                          <span
-                            className={`status-indicator status-${row.status}`}
-                            aria-label={buildStatusText(row.status)}
-                            title={buildStatusText(row.status)}
-                          />
-                          <span className="signals-incident-kind">
-                            {row.typeLabel}
+                          <span className="signals-incident-indicator-wrap">
+                            <span
+                              className={`status-indicator status-${row.status}`}
+                              aria-label={buildStatusText(row.status)}
+                              title={buildStatusText(row.status)}
+                            />
                           </span>
-                          <span className="signal-name" title={row.title}>
-                            {row.title}
+                          <span className="signals-incident-text-stack">
+                            <span className="signals-incident-kind">
+                              {row.typeLabel}
+                            </span>
+                            <span className="signal-name" title={row.title}>
+                              {row.title}
+                            </span>
                           </span>
                         </div>
                         {row.signals && row.signals.length > 0 && (
@@ -595,16 +619,20 @@ export default function DetailsPanel({
                     ) : (
                       <>
                         <div className="signals-incident-title">
-                          <span
-                            className={`status-indicator status-${row.status}`}
-                            aria-label={buildStatusText(row.status)}
-                            title={buildStatusText(row.status)}
-                          />
-                          <span className="signals-incident-kind">
-                            {row.typeLabel}
+                          <span className="signals-incident-indicator-wrap">
+                            <span
+                              className={`status-indicator status-${row.status}`}
+                              aria-label={buildStatusText(row.status)}
+                              title={buildStatusText(row.status)}
+                            />
                           </span>
-                          <span className="signal-name" title={row.title}>
-                            {row.title}
+                          <span className="signals-incident-text-stack">
+                            <span className="signals-incident-kind">
+                              {row.typeLabel}
+                            </span>
+                            <span className="signal-name" title={row.title}>
+                              {row.title}
+                            </span>
                           </span>
                         </div>
                         {row.signals && row.signals.length > 0 && (

--- a/services-core/aggregator-ui/src/components/DetailsPanel.tsx
+++ b/services-core/aggregator-ui/src/components/DetailsPanel.tsx
@@ -415,7 +415,8 @@ export default function DetailsPanel({
                     <span className="chip-text-block">
                       <span className="chip-prefix">Owner</span>
                       <span className="ownership-contact-value">
-                        {ownerActorForContacts.title || ownerActorForContacts.id}
+                        {ownerActorForContacts.title ||
+                          ownerActorForContacts.id}
                       </span>
                     </span>
                   </span>
@@ -442,7 +443,10 @@ export default function DetailsPanel({
                   >
                     <span className="chip-entry">
                       <span className="chip-icon-block">
-                        {renderContactTypeIcon(iconSpriteHref, primaryContact.type)}
+                        {renderContactTypeIcon(
+                          iconSpriteHref,
+                          primaryContact.type,
+                        )}
                       </span>
                       <span className="chip-text-block">
                         <span className="chip-prefix">Primary contact</span>
@@ -506,7 +510,7 @@ export default function DetailsPanel({
                               </span>
                               <span className="chip-text-block">
                                 <span className="chip-prefix">
-                                {entry.typeLabel}
+                                  {entry.typeLabel}
                                 </span>
                                 <span className="ownership-contact-value">
                                   {entry.actor.title || entry.actor.id}
@@ -566,7 +570,9 @@ export default function DetailsPanel({
                                 />
                               </span>
                               <span className="signals-incident-text-stack">
-                                <span className="signals-incident-kind">Own</span>
+                                <span className="signals-incident-kind">
+                                  Own
+                                </span>
                                 <span
                                   className="signal-name"
                                   title={entry.title || entry.id}


### PR DESCRIPTION
- Reworked ownership section to use unified chip layout with icon, prefix, and value stacked in two lines.
- Embedded “Owner” and “Primary contact” labels directly into chip structure instead of separate headers.
- Refactored actor and contact rows to align with shared chip entry pattern.
- Standardized rendering of ownership-related entries with consistent spacing and alignment.
- Reworked signals list items to use structured layout with separated status indicator and text stack.
- Introduced clearer distinction between signal type (e.g., Own, dependency) and signal name within incidents.

## Result
- Ownership and signals sections now follow a consistent visual and structural pattern.
- Improved readability and scanability of labels versus values.
- Reduced visual noise by removing redundant section labels and consolidating information into chips.